### PR TITLE
Allow to define rpc codec using env

### DIFF
--- a/src/Bootloader/RoadRunnerBootloader.php
+++ b/src/Bootloader/RoadRunnerBootloader.php
@@ -46,7 +46,7 @@ final class RoadRunnerBootloader extends Bootloader
         $container->bindSingleton(RPC::class, static function (EnvironmentInterface $env, GlobalEnvironmentInterface $globalEnv): RPCInterface {
             return new RPC(
                 Relay::create($env->getRPCAddress()),
-                $this->withCodec($globalEnv),
+                self::withCodec($globalEnv),
             );
         });
 
@@ -73,7 +73,7 @@ final class RoadRunnerBootloader extends Bootloader
         });
     }
 
-    private function withCodec(GlobalEnvironmentInterface $env): CodecInterface
+    private static function withCodec(GlobalEnvironmentInterface $env): CodecInterface
     {
         switch ($env->get('RPC_CODEC')) {
             case 'proto':


### PR DESCRIPTION
At the moment, the `RPC` always uses `JsonCodec`, which can only be overridden in the application side bootloader. This PR will allow to specify codec from environment variables using `RPC_CODEC` env.