### PR TITLE
Added RoadRunner metrics support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "spiral/roadrunner-kv": "^2.0",
     "spiral/roadrunner-broadcast": "^2.0",
     "spiral/roadrunner-tcp": "^2.0",
+    "spiral/roadrunner-metrics": "^2.0",
     "spiral/framework": "^2.13"
   },
   "require-dev": {

--- a/src/Bootloader/MetricsBootloader.php
+++ b/src/Bootloader/MetricsBootloader.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\Bootloader;
+
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Goridge\RPC\RPCInterface;
+use Spiral\RoadRunner\Metrics\Metrics;
+use Spiral\RoadRunner\Metrics\MetricsInterface;
+
+final class MetricsBootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        RoadRunnerBootloader::class,
+    ];
+
+    protected const SINGLETONS = [
+        MetricsInterface::class => [self::class, 'initMetrics'],
+    ];
+
+    protected function initMetrics(RPCInterface $rpc): MetricsInterface
+    {
+        return new Metrics($rpc);
+    }
+}

--- a/tests/App/App.php
+++ b/tests/App/App.php
@@ -22,6 +22,7 @@ class App extends Kernel
         RoadRunnerBridge\BroadcastingBootloader::class,
         RoadRunnerBridge\RoadRunnerBootloader::class,
         RoadRunnerBridge\TcpBootloader::class,
+        RoadRunnerBridge\MetricsBootloader::class,
 
         // Framework commands
         Framework\ConsoleBootloader::class,

--- a/tests/src/Bootloader/MetricsBootloaderTest.php
+++ b/tests/src/Bootloader/MetricsBootloaderTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Bootloader;
+
+use Spiral\RoadRunner\Metrics\Metrics;
+use Spiral\RoadRunner\Metrics\MetricsInterface;
+use Spiral\Tests\TestCase;
+
+final class MetricsBootloaderTest extends TestCase
+{
+    public function testMetricsInterfaceBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(MetricsInterface::class, Metrics::class);
+    }
+}


### PR DESCRIPTION
Add `Spiral\RoadRunnerBridge\Bootloader\MetricsBootloader` to application bootloaders list:

```php
use Spiral\RoadRunnerBridge\Bootloader as RoadRunnerBridge;

protected const LOAD = [
    // ...
    RoadRunnerBridge\MetricsBootloader::class, 
    // ...
];
```

First, you have to register a metric in your configuration file:

```yaml
metrics:
  address: localhost:2112
  collect:
    app_metric_counter:
      type: counter
      help: "Application counter."
```

or declare metrics in PHP code

```php
use Spiral\RoadRunner\Metrics\MetricsInterface;
use Spiral\RoadRunner\Metrics\Collector;

class AppBootloader extends Bootloader
{
    //...

    public function boot(MetricsInterface $metrics): void
    {
        $metrics->declare(
            'app_metric_counter',
            Collector::counter()->withHelp('Application counter.')
        );
    }
}
```

To populate metric from application use `Spiral\RoadRunner\Metrics\MetricsInterface`:

```php
use Spiral\RoadRunner\Metrics\MetricsInterface; 

// ...

public function index(MetricsInterface $metrics): void
{
    $metrics->add('app_metric_counter', 1);
}
```