### PR TITLE
Adding the ability to configure serializers for different types of jobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "spiral/roadrunner-kv": "^2.2",
     "spiral/roadrunner-broadcast": "^2.0",
     "spiral/roadrunner-tcp": "^2.0",
+    "spiral/roadrunner-metrics": "^2.0",
     "spiral/framework": "^3.0.x-dev",
     "spiral/serializer": "^3.0"
   },

--- a/src/Bootloader/MetricsBootloader.php
+++ b/src/Bootloader/MetricsBootloader.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\Bootloader;
+
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Goridge\RPC\RPCInterface;
+use Spiral\RoadRunner\Metrics\Metrics;
+use Spiral\RoadRunner\Metrics\MetricsInterface;
+
+final class MetricsBootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        RoadRunnerBootloader::class,
+    ];
+
+    protected const SINGLETONS = [
+        MetricsInterface::class => [self::class, 'initMetrics'],
+    ];
+
+    protected function initMetrics(RPCInterface $rpc): MetricsInterface
+    {
+        return new Metrics($rpc);
+    }
+}

--- a/src/Bootloader/QueueBootloader.php
+++ b/src/Bootloader/QueueBootloader.php
@@ -9,8 +9,7 @@ use Spiral\Boot\KernelInterface;
 use Spiral\Core\Container;
 use Spiral\Goridge\RPC\RPCInterface;
 use Spiral\Queue\Bootloader\QueueBootloader as BaseQueueBootloader;
-use Spiral\Queue\Config\QueueConfig;
-use Spiral\Queue\HandlerRegistryInterface;
+use Spiral\Queue\SerializerRegistryInterface;
 use Spiral\RoadRunnerBridge\Queue\Consumer;
 use Spiral\Serializer\Bootloader\SerializerBootloader;
 use Spiral\RoadRunner\Jobs\ConsumerInterface;
@@ -23,7 +22,6 @@ use Spiral\RoadRunnerBridge\Queue\JobsAdapterSerializer;
 use Spiral\RoadRunnerBridge\Queue\PipelineRegistryInterface;
 use Spiral\RoadRunnerBridge\Queue\Queue;
 use Spiral\RoadRunnerBridge\Queue\RPCPipelineRegistry;
-use Spiral\Serializer\SerializerManager;
 
 final class QueueBootloader extends Bootloader
 {
@@ -51,12 +49,7 @@ final class QueueBootloader extends Bootloader
     {
         $container->bindSingleton(
             JobsAdapterSerializer::class,
-            static fn (SerializerManager $manager, QueueConfig $config, HandlerRegistryInterface $registry) =>
-                new JobsAdapterSerializer(
-                    $manager,
-                    $registry,
-                    $config->getConnections('roadrunner')['roadrunner']['serializerFormat'] ?? null
-                )
+            static fn (SerializerRegistryInterface $registry) => new JobsAdapterSerializer($registry)
         );
 
         $container->bindSingleton(RRSerializerInterface::class, JobsAdapterSerializer::class);
@@ -66,12 +59,8 @@ final class QueueBootloader extends Bootloader
     {
         $container->bindSingleton(
             ConsumerInterface::class,
-            static fn (JobsAdapterSerializer $serializer, WorkerInterface $worker, QueueConfig $config): Consumer =>
-                new Consumer(
-                    $serializer,
-                    $worker,
-                    $config->getConnections('roadrunner')['roadrunner']['pipelines'] ?? []
-                )
+            static fn (JobsAdapterSerializer $serializer, WorkerInterface $worker): Consumer =>
+                new Consumer($serializer, $worker)
         );
     }
 

--- a/src/Bootloader/QueueBootloader.php
+++ b/src/Bootloader/QueueBootloader.php
@@ -55,7 +55,7 @@ final class QueueBootloader extends Bootloader
                 new JobsAdapterSerializer(
                     $manager,
                     $registry,
-                $config->getConnections('roadrunner')['roadrunner']['serializerFormat'] ?? null
+                    $config->getConnections('roadrunner')['roadrunner']['serializerFormat'] ?? null
                 )
         );
 

--- a/src/Bootloader/QueueBootloader.php
+++ b/src/Bootloader/QueueBootloader.php
@@ -10,6 +10,7 @@ use Spiral\Core\Container;
 use Spiral\Goridge\RPC\RPCInterface;
 use Spiral\Queue\Bootloader\QueueBootloader as BaseQueueBootloader;
 use Spiral\Queue\Config\QueueConfig;
+use Spiral\Queue\HandlerRegistryInterface;
 use Spiral\RoadRunnerBridge\Queue\Consumer;
 use Spiral\Serializer\Bootloader\SerializerBootloader;
 use Spiral\RoadRunner\Jobs\ConsumerInterface;
@@ -50,10 +51,12 @@ final class QueueBootloader extends Bootloader
     {
         $container->bindSingleton(
             JobsAdapterSerializer::class,
-            static fn (SerializerManager $manager, QueueConfig $config) => new JobsAdapterSerializer(
-                $manager,
+            static fn (SerializerManager $manager, QueueConfig $config, HandlerRegistryInterface $registry) =>
+                new JobsAdapterSerializer(
+                    $manager,
+                    $registry,
                 $config->getConnections('roadrunner')['roadrunner']['serializerFormat'] ?? null
-            )
+                )
         );
 
         $container->bindSingleton(RRSerializerInterface::class, JobsAdapterSerializer::class);

--- a/src/Queue/Consumer.php
+++ b/src/Queue/Consumer.php
@@ -39,7 +39,7 @@ final class Consumer implements ConsumerInterface
             $header['id'],
             $header['pipeline'],
             $header['job'],
-            $this->getPayload($payload, $header['pipeline'],  $header['job']),
+            $this->getPayload($payload, $header['pipeline'], $header['job']),
             (array) $header['headers']
         );
     }

--- a/src/Queue/Consumer.php
+++ b/src/Queue/Consumer.php
@@ -10,6 +10,7 @@ use Spiral\RoadRunner\Jobs\Task\ReceivedTaskInterface;
 use Spiral\RoadRunner\Payload;
 use Spiral\RoadRunner\Worker;
 use Spiral\RoadRunner\WorkerInterface;
+use Spiral\Serializer\Exception\SerializeException;
 use Spiral\Serializer\Exception\UnserializeException;
 
 final class Consumer implements ConsumerInterface
@@ -18,8 +19,7 @@ final class Consumer implements ConsumerInterface
 
     public function __construct(
         private readonly JobsAdapterSerializer $serializer,
-        WorkerInterface $worker = null,
-        private readonly array $pipelines = [],
+        WorkerInterface $worker = null
     ) {
         $this->worker = $worker ?? Worker::create();
     }
@@ -32,14 +32,14 @@ final class Consumer implements ConsumerInterface
             return null;
         }
 
-        $header = $this->serializer->withFormat('json')->deserialize($payload->header);
+        $header = $this->getHeader($payload);
 
         return new ReceivedTask(
             $this->worker,
             $header['id'],
             $header['pipeline'],
             $header['job'],
-            $this->getPayload($payload, $header['pipeline'], $header['job']),
+            $this->getPayload($payload, $header['job']),
             (array) $header['headers']
         );
     }
@@ -47,11 +47,17 @@ final class Consumer implements ConsumerInterface
     /**
      * @throws UnserializeException
      */
-    private function getPayload(Payload $payload, string $pipeline, string $jobType): array
+    private function getPayload(Payload $payload, string $jobType): array
     {
-        return $this->serializer
-            ->withFormat($this->pipelines[$pipeline]['serializerFormat'] ?? null)
-            ->withJobType($jobType)
-            ->deserialize($payload->body);
+        return $this->serializer->changeSerializer($jobType)->deserialize($payload->body);
+    }
+
+    private function getHeader(Payload $payload): array
+    {
+        try {
+            return (array) \json_decode($payload->header, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new SerializeException($e->getMessage(), (int)$e->getCode(), $e);
+        }
     }
 }

--- a/src/Queue/Consumer.php
+++ b/src/Queue/Consumer.php
@@ -39,7 +39,7 @@ final class Consumer implements ConsumerInterface
             $header['id'],
             $header['pipeline'],
             $header['job'],
-            $this->getPayload($payload, $header['pipeline']),
+            $this->getPayload($payload, $header['pipeline'],  $header['job']),
             (array) $header['headers']
         );
     }
@@ -47,10 +47,11 @@ final class Consumer implements ConsumerInterface
     /**
      * @throws UnserializeException
      */
-    private function getPayload(Payload $payload, string $pipeline): array
+    private function getPayload(Payload $payload, string $pipeline, string $jobType): array
     {
         return $this->serializer
             ->withFormat($this->pipelines[$pipeline]['serializerFormat'] ?? null)
+            ->withJobType($jobType)
             ->deserialize($payload->body);
     }
 }

--- a/src/Queue/JobsAdapterSerializer.php
+++ b/src/Queue/JobsAdapterSerializer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunnerBridge\Queue;
 
+use Spiral\Queue\HandlerRegistryInterface;
+use Spiral\Queue\QueueRegistry;
 use Spiral\RoadRunner\Jobs\Serializer\SerializerInterface;
 use Spiral\Serializer\SerializerManager;
 
@@ -14,8 +16,21 @@ final class JobsAdapterSerializer implements SerializerInterface
 {
     public function __construct(
         private readonly SerializerManager $manager,
+        private readonly HandlerRegistryInterface $handlerRegistry,
         private ?string $format = null
     ) {
+    }
+
+    public function withJobType(string $jobType): self
+    {
+        if ($this->handlerRegistry instanceof QueueRegistry && $this->handlerRegistry->hasSerializer($jobType)) {
+            $serializer = clone $this;
+            $serializer->format = $this->handlerRegistry->getSerializerFormat($jobType);
+
+            return $serializer;
+        }
+
+        return $this;
     }
 
     public function withFormat(string $format = null): self

--- a/src/Queue/JobsAdapterSerializer.php
+++ b/src/Queue/JobsAdapterSerializer.php
@@ -4,54 +4,38 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunnerBridge\Queue;
 
-use Spiral\Queue\HandlerRegistryInterface;
-use Spiral\Queue\QueueRegistry;
+use Spiral\Queue\SerializerRegistryInterface;
+use Spiral\Serializer\SerializerInterface as SpiralSerializer;
 use Spiral\RoadRunner\Jobs\Serializer\SerializerInterface;
-use Spiral\Serializer\SerializerManager;
 
 /**
  * @internal
  */
 final class JobsAdapterSerializer implements SerializerInterface
 {
+    private SpiralSerializer $serializer;
+
     public function __construct(
-        private readonly SerializerManager $manager,
-        private readonly HandlerRegistryInterface $handlerRegistry,
-        private ?string $format = null
+        private readonly SerializerRegistryInterface $registry
     ) {
+        $this->serializer = $registry->getSerializer();
     }
 
-    public function withJobType(string $jobType): self
+    public function changeSerializer(string $jobType): self
     {
-        if ($this->handlerRegistry instanceof QueueRegistry && $this->handlerRegistry->hasSerializer($jobType)) {
-            $serializer = clone $this;
-            $serializer->format = $this->handlerRegistry->getSerializerFormat($jobType);
-
-            return $serializer;
-        }
-
-        return $this;
-    }
-
-    public function withFormat(string $format = null): self
-    {
-        if ($format === null) {
-            return $this;
-        }
-
         $serializer = clone $this;
-        $serializer->format = $format;
+        $serializer->serializer = $this->registry->getSerializer($jobType);
 
         return $serializer;
     }
 
     public function serialize(array $payload): string
     {
-        return (string) $this->manager->getSerializer($this->format)->serialize($payload);
+        return $this->serializer->serialize($payload);
     }
 
     public function deserialize(string $payload): array
     {
-        return $this->manager->getSerializer($this->format)->unserialize($payload);
+        return $this->serializer->unserialize($payload);
     }
 }

--- a/src/Queue/JobsAdapterSerializer.php
+++ b/src/Queue/JobsAdapterSerializer.php
@@ -31,7 +31,7 @@ final class JobsAdapterSerializer implements SerializerInterface
 
     public function serialize(array $payload): string
     {
-        return $this->serializer->serialize($payload);
+        return (string) $this->serializer->serialize($payload);
     }
 
     public function deserialize(string $payload): array

--- a/src/Queue/PipelineRegistryInterface.php
+++ b/src/Queue/PipelineRegistryInterface.php
@@ -16,5 +16,5 @@ interface PipelineRegistryInterface
      *
      * If pipeline not exists in the RoadRunner, it will be created
      */
-    public function getPipeline(string $name): QueueInterface;
+    public function getPipeline(string $name, string $jobType): QueueInterface;
 }

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -41,9 +41,7 @@ final class Queue implements QueueInterface
      */
     public function push(string $name, array $payload = [], OptionsInterface $options = null): string
     {
-        $queue = $this->initQueue(
-            $options ? $options->getQueue() ?? $this->default : $this->default
-        );
+        $queue = $this->initQueue($name, $options ? $options->getQueue() ?? $this->default : $this->default);
 
         $task = $queue->dispatch(
             $queue->create(
@@ -56,7 +54,7 @@ final class Queue implements QueueInterface
         return $task->getId();
     }
 
-    private function initQueue(?string $pipeline): RRQueueInterface
+    private function initQueue(string $jobType, ?string $pipeline): RRQueueInterface
     {
         if (! $pipeline) {
             throw new InvalidArgumentException('You must define default RoadRunner queue pipeline.');
@@ -71,6 +69,6 @@ final class Queue implements QueueInterface
             'aliases' => $this->aliases,
         ]);
 
-        return $this->queues[$pipeline] = $registry->getPipeline($pipeline);
+        return $this->queues[$pipeline] = $registry->getPipeline($pipeline, $jobType);
     }
 }

--- a/src/Queue/RPCPipelineRegistry.php
+++ b/src/Queue/RPCPipelineRegistry.php
@@ -39,9 +39,7 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
         }
 
         if (! isset($this->pipelines[$name])) {
-            throw new InvalidArgumentException(
-                \sprintf('Queue pipeline with given name `%s` is not found.', $name)
-            );
+            return $this->jobs->connect($name);
         }
 
         if (! isset($this->pipelines[$name]['connector'])) {
@@ -62,15 +60,13 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
 
         /** @var CreateInfoInterface $connector */
         $connector = $this->pipelines[$name]['connector'];
-        $consume = (bool)($this->pipelines[$name]['consume'] ?? true);
 
         if (! $this->isExists($connector)) {
-            $queue = $this->create($connector, $consume);
-        } else {
-            $queue = $this->connect($connector);
+            $consume = (bool)($this->pipelines[$name]['consume'] ?? true);
+            return $this->create($connector, $consume);
         }
 
-        return $queue;
+        return $this->connect($connector);
     }
 
     /**

--- a/src/Queue/RPCPipelineRegistry.php
+++ b/src/Queue/RPCPipelineRegistry.php
@@ -57,11 +57,7 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
         }
 
         if ($this->jobs instanceof SerializerAwareInterface) {
-            $this->jobs = $this->jobs->withSerializer(
-                $this->serializer
-                    ->withFormat($this->pipelines[$name]['serializerFormat'] ?? null)
-                    ->withJobType($jobType)
-            );
+            $this->jobs = $this->jobs->withSerializer($this->serializer->changeSerializer($jobType));
         }
 
         /** @var CreateInfoInterface $connector */

--- a/src/Queue/RPCPipelineRegistry.php
+++ b/src/Queue/RPCPipelineRegistry.php
@@ -32,7 +32,7 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
     ) {
     }
 
-    public function getPipeline(string $name): QueueInterface
+    public function getPipeline(string $name, string $jobType): QueueInterface
     {
         if (isset($this->aliases[$name])) {
             $name = $this->aliases[$name];
@@ -56,9 +56,11 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
             );
         }
 
-        if ($this->jobs instanceof SerializerAwareInterface && !empty($this->pipelines[$name]['serializerFormat'])) {
+        if ($this->jobs instanceof SerializerAwareInterface) {
             $this->jobs = $this->jobs->withSerializer(
-                $this->serializer->withFormat($this->pipelines[$name]['serializerFormat'])
+                $this->serializer
+                    ->withFormat($this->pipelines[$name]['serializerFormat'] ?? null)
+                    ->withJobType($jobType)
             );
         }
 

--- a/tests/app/Job/TestJob.php
+++ b/tests/app/Job/TestJob.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Job;
+
+use Spiral\Queue\HandlerInterface;
+
+final class TestJob implements HandlerInterface
+{
+    public function handle(string $name, string $id, array $payload): void
+    {
+    }
+}

--- a/tests/app/config/queue.php
+++ b/tests/app/config/queue.php
@@ -46,7 +46,6 @@ return [
                 ],
                 'withSerializer' => [
                     'connector' => new MemoryCreateInfo('local'),
-                    'serializerFormat' => 'serializer',
                     'consume' => true,
                 ],
                 // 'amqp' => [
@@ -77,7 +76,7 @@ return [
         'handlers' => [],
         'serializers' => [
             \Spiral\Queue\Job\ObjectJob::class => 'json',
-            \Spiral\App\Job\TestJob::class => 'serializer',
+            \Spiral\App\Job\TestJob::class => new \Spiral\Serializer\Serializer\PhpSerializer(),
         ],
     ],
 ];

--- a/tests/app/config/queue.php
+++ b/tests/app/config/queue.php
@@ -77,7 +77,7 @@ return [
         'handlers' => [],
         'serializers' => [
             \Spiral\Queue\Job\ObjectJob::class => 'json',
-            \Spiral\App\Job\TestJob::class => 'serializer'
-        ]
+            \Spiral\App\Job\TestJob::class => 'serializer',
+        ],
     ],
 ];

--- a/tests/app/config/queue.php
+++ b/tests/app/config/queue.php
@@ -75,5 +75,9 @@ return [
 
     'registry' => [
         'handlers' => [],
+        'serializers' => [
+            \Spiral\Queue\Job\ObjectJob::class => 'json',
+            \Spiral\App\Job\TestJob::class => 'serializer'
+        ]
     ],
 ];

--- a/tests/src/Bootloader/MetricsBootloaderTest.php
+++ b/tests/src/Bootloader/MetricsBootloaderTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Bootloader;
+
+use Spiral\RoadRunner\Metrics\Metrics;
+use Spiral\RoadRunner\Metrics\MetricsInterface;
+use Spiral\Tests\TestCase;
+
+final class MetricsBootloaderTest extends TestCase
+{
+    public function testMetricsInterfaceBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(MetricsInterface::class, Metrics::class);
+    }
+}

--- a/tests/src/Bootloader/QueueBootloaderTest.php
+++ b/tests/src/Bootloader/QueueBootloaderTest.php
@@ -7,7 +7,6 @@ namespace Spiral\Tests\Bootloader;
 use Mockery as m;
 use Spiral\Core\ConfigsInterface;
 use Spiral\Exceptions\ExceptionReporterInterface;
-use Spiral\Queue\Config\QueueConfig;
 use Spiral\Queue\HandlerRegistryInterface;
 use Spiral\Queue\QueueInterface;
 use Spiral\Serializer\SerializerInterface;
@@ -129,32 +128,5 @@ final class QueueBootloaderTest extends TestCase
         $config = $configurator->getConfig('queue');
 
         $this->assertIsArray($config);
-    }
-
-    public function testFormatIsNull(): void
-    {
-        $serializer = $this->getContainer()->get(JobsAdapterSerializer::class);
-
-        $ref = new \ReflectionObject($serializer);
-
-        $this->assertNull($ref->getProperty('format')->getValue($serializer));
-    }
-
-    public function testFormatIsDefined(): void
-    {
-        $this->getContainer()->bind(QueueConfig::class, new QueueConfig([
-            'connections' => [
-                'roadrunner' => [
-                    'driver' => 'roadrunner',
-                    'serializerFormat' => 'defined',
-                ],
-            ],
-        ]));
-
-        $serializer = $this->getContainer()->get(JobsAdapterSerializer::class);
-
-        $ref = new \ReflectionObject($serializer);
-
-        $this->assertSame('defined', $ref->getProperty('format')->getValue($serializer));
     }
 }

--- a/tests/src/Queue/ConsumerTest.php
+++ b/tests/src/Queue/ConsumerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Spiral\Tests\Queue;
 
 use Spiral\App\Job\TestJob;
-use Spiral\Queue\Job\ObjectJob;
 use Spiral\RoadRunner\Jobs\ConsumerInterface;
 use Spiral\RoadRunner\Payload;
 use Spiral\Tests\TestCase;
@@ -13,13 +12,13 @@ use Spiral\Tests\TestCase;
 final class ConsumerTest extends TestCase
 {
     /** @dataProvider payloadSerializationDataProvider */
-    public function testGetPayloadWithDefaultSerializer(Payload $payload, string $pipeline, string $jobType): void
+    public function testGetPayload(Payload $payload, string $jobType): void
     {
         $consumer = $this->getContainer()->get(ConsumerInterface::class);
 
         $ref = new \ReflectionMethod($consumer, 'getPayload');
 
-        $result = $ref->invoke($consumer, $payload, $pipeline, $jobType);
+        $result = $ref->invoke($consumer, $payload, $jobType);
 
         $this->assertSame(['test' => 'test', 'other' => 'data'], $result);
     }
@@ -27,15 +26,9 @@ final class ConsumerTest extends TestCase
     public function payloadSerializationDataProvider(): \Traversable
     {
         // default json serializer
-        yield [new Payload(\json_encode(['test' => 'test', 'other' => 'data'])), 'memory', 'some'];
+        yield [new Payload(\json_encode(['test' => 'test', 'other' => 'data'])), 'some'];
 
-        // php serialize from the pipeline config
-        yield [new Payload(\serialize(['test' => 'test', 'other' => 'data'])), 'withSerializer', 'some'];
-
-        // Serializer in `memory` pipeline is not set (`json` by default). TestJob set serializer to `serializer`
-        yield [new Payload(\serialize(['test' => 'test', 'other' => 'data'])), 'memory', TestJob::class];
-
-        // Serializer in `withSerializer` pipeline is `serializer`. ObjectJob override serializer to `json`
-        yield [new Payload(\json_encode(['test' => 'test', 'other' => 'data',])), 'withSerializer', ObjectJob::class];
+        // TestJob set serializer to `serializer`
+        yield [new Payload(\serialize(['test' => 'test', 'other' => 'data'])), TestJob::class];
     }
 }

--- a/tests/src/Queue/JobsAdapterSerializerTest.php
+++ b/tests/src/Queue/JobsAdapterSerializerTest.php
@@ -7,31 +7,20 @@ namespace Spiral\Tests\Queue;
 use Spiral\App\Job\TestJob;
 use Spiral\Queue\Job\ObjectJob;
 use Spiral\RoadRunnerBridge\Queue\JobsAdapterSerializer;
+use Spiral\Serializer\Serializer\JsonSerializer;
+use Spiral\Serializer\Serializer\PhpSerializer;
 use Spiral\Tests\TestCase;
 
 final class JobsAdapterSerializerTest extends TestCase
 {
-    public function testWithJobType(): void
+    public function testJobSerializer(): void
     {
         $serializer = $this->getContainer()->get(JobsAdapterSerializer::class);
 
-        $ref = new \ReflectionProperty($serializer, 'format');
+        $ref = new \ReflectionProperty($serializer, 'serializer');
 
-        $this->assertNull($ref->getValue($serializer));
-        $this->assertSame('serializer', $ref->getValue($serializer->withJobType(TestJob::class)));
-        $this->assertSame('json', $ref->getValue($serializer->withJobType(ObjectJob::class)));
-        $this->assertNull($ref->getValue($serializer->withJobType('some')));
-    }
-
-    public function testWithFormat(): void
-    {
-        $serializer = $this->getContainer()->get(JobsAdapterSerializer::class);
-
-        $ref = new \ReflectionProperty($serializer, 'format');
-
-        $this->assertNull($ref->getValue($serializer));
-        $this->assertSame('serializer', $ref->getValue($serializer->withFormat('serializer')));
-        $this->assertSame('json', $ref->getValue($serializer->withFormat('json')));
-        $this->assertNull($ref->getValue($serializer->withFormat()));
+        $this->assertInstanceOf(JsonSerializer::class, $ref->getValue($serializer));
+        $this->assertInstanceOf(PhpSerializer::class, $ref->getValue($serializer->changeSerializer(TestJob::class)));
+        $this->assertInstanceOf(JsonSerializer::class, $ref->getValue($serializer->changeSerializer(ObjectJob::class)));
     }
 }

--- a/tests/src/Queue/JobsAdapterSerializerTest.php
+++ b/tests/src/Queue/JobsAdapterSerializerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use Spiral\App\Job\TestJob;
+use Spiral\Queue\Job\ObjectJob;
+use Spiral\RoadRunnerBridge\Queue\JobsAdapterSerializer;
+use Spiral\Tests\TestCase;
+
+final class JobsAdapterSerializerTest extends TestCase
+{
+    public function testWithJobType(): void
+    {
+        $serializer = $this->getContainer()->get(JobsAdapterSerializer::class);
+
+        $ref = new \ReflectionProperty($serializer, 'format');
+
+        $this->assertNull($ref->getValue($serializer));
+        $this->assertSame('serializer', $ref->getValue($serializer->withJobType(TestJob::class)));
+        $this->assertSame('json', $ref->getValue($serializer->withJobType(ObjectJob::class)));
+        $this->assertNull($ref->getValue($serializer->withJobType('some')));
+    }
+
+    public function testWithFormat(): void
+    {
+        $serializer = $this->getContainer()->get(JobsAdapterSerializer::class);
+
+        $ref = new \ReflectionProperty($serializer, 'format');
+
+        $this->assertNull($ref->getValue($serializer));
+        $this->assertSame('serializer', $ref->getValue($serializer->withFormat('serializer')));
+        $this->assertSame('json', $ref->getValue($serializer->withFormat('json')));
+        $this->assertNull($ref->getValue($serializer->withFormat()));
+    }
+}

--- a/tests/src/Queue/QueueManagerTest.php
+++ b/tests/src/Queue/QueueManagerTest.php
@@ -41,7 +41,7 @@ class QueueManagerTest extends TestCase
     {
         $this->registry->shouldReceive('getPipeline')
             ->once()
-            ->with('memory')
+            ->with('memory', 'foo')
             ->andReturn($queue = m::mock(QueueInterface::class));
 
         $queuedTask = m::mock(QueuedTaskInterface::class);

--- a/tests/src/Queue/QueueTest.php
+++ b/tests/src/Queue/QueueTest.php
@@ -45,11 +45,11 @@ final class QueueTest extends TestCase
         $this->queue = new Queue($container, $pipelines, $aliases, 'default');
     }
 
-    public function testTaskShouldBePushedToDefaultQueue()
+    public function testTaskShouldBePushedToDefaultQueue(): void
     {
         $this->registry->shouldReceive('getPipeline')
             ->once()
-            ->with('default')
+            ->with('default', 'foo')
             ->andReturn($queue = m::mock(QueueInterface::class));
 
         $queuedTask = m::mock(QueuedTaskInterface::class);
@@ -64,16 +64,16 @@ final class QueueTest extends TestCase
         $this->assertSame('task-id2', $this->queue->push('foo', ['foo' => 'bar']));
     }
 
-    public function testTaskShouldBePushedToCustomQueue()
+    public function testTaskShouldBePushedToCustomQueue(): void
     {
         $this->registry->shouldReceive('getPipeline')
             ->once()
-            ->with('foo')
+            ->with('foo', 'foo')
             ->andReturn($fooQueue = m::mock(QueueInterface::class));
 
         $this->registry->shouldReceive('getPipeline')
             ->once()
-            ->with('bar')
+            ->with('bar', 'bar')
             ->andReturn($barQueue = m::mock(QueueInterface::class));
 
         $queuedTask = m::mock(QueuedTaskInterface::class);
@@ -91,11 +91,11 @@ final class QueueTest extends TestCase
         $this->assertSame('task-id2', $this->queue->push('bar', ['foo' => 'bar'], Options::onQueue('bar')));
     }
 
-    public function testPushObject()
+    public function testPushObject(): void
     {
         $this->registry->shouldReceive('getPipeline')
             ->once()
-            ->with('default')
+            ->with('default', ObjectJob::class)
             ->andReturn($queue = m::mock(QueueInterface::class));
 
         $object = new \stdClass();

--- a/tests/src/Queue/RPCPipelineRegistryTest.php
+++ b/tests/src/Queue/RPCPipelineRegistryTest.php
@@ -121,20 +121,24 @@ final class RPCPipelineRegistryTest extends TestCase
         );
     }
 
-    public function testGetsNonExistsPipelineShouldThrowAnException(): void
+    public function testGetsNonExistsPipelineShouldReturnQueue(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage('Queue pipeline with given name `test` is not found.');
+        $this->jobs->shouldReceive('connect')
+            ->once()
+            ->with('test')
+            ->andReturn($queue = m::mock(QueueInterface::class));
 
-        $this->registry->getPipeline('test', 'some');
+        $this->assertSame($queue, $this->registry->getPipeline('test', 'some'));
     }
 
-    public function testGetsNonExistsAliasPipelineShouldThrowAnException(): void
+    public function testGetsNonExistsAliasPipelineShouldReturnQueue(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage('Queue pipeline with given name `test` is not found.');
+        $this->jobs->shouldReceive('connect')
+            ->once()
+            ->with('test')
+            ->andReturn($queue = m::mock(QueueInterface::class));
 
-        $this->registry->getPipeline('bad-alias', 'some');
+        $this->assertSame($queue, $this->registry->getPipeline('bad-alias', 'some'));
     }
 
     public function testGetsPipelineWithoutConnectorShouldThrowAnException(): void

--- a/tests/src/Queue/RPCPipelineRegistryTest.php
+++ b/tests/src/Queue/RPCPipelineRegistryTest.php
@@ -65,7 +65,7 @@ final class RPCPipelineRegistryTest extends TestCase
 
         $this->assertInstanceOf(
             QueueInterface::class,
-            $this->registry->getPipeline('memory')
+            $this->registry->getPipeline('memory', 'some')
         );
     }
 
@@ -83,7 +83,7 @@ final class RPCPipelineRegistryTest extends TestCase
 
         $this->assertInstanceOf(
             QueueInterface::class,
-            $this->registry->getPipeline('memory')
+            $this->registry->getPipeline('memory', 'some')
         );
     }
 
@@ -99,7 +99,7 @@ final class RPCPipelineRegistryTest extends TestCase
 
         $this->assertInstanceOf(
             QueueInterface::class,
-            $this->registry->getPipeline('local')
+            $this->registry->getPipeline('local', 'some')
         );
     }
 
@@ -117,7 +117,7 @@ final class RPCPipelineRegistryTest extends TestCase
 
         $this->assertInstanceOf(
             QueueInterface::class,
-            $this->registry->getPipeline('user-data')
+            $this->registry->getPipeline('user-data', 'some')
         );
     }
 
@@ -126,7 +126,7 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectErrorMessage('Queue pipeline with given name `test` is not found.');
 
-        $this->registry->getPipeline('test');
+        $this->registry->getPipeline('test', 'some');
     }
 
     public function testGetsNonExistsAliasPipelineShouldThrowAnException(): void
@@ -134,7 +134,7 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectErrorMessage('Queue pipeline with given name `test` is not found.');
 
-        $this->registry->getPipeline('bad-alias');
+        $this->registry->getPipeline('bad-alias', 'some');
     }
 
     public function testGetsPipelineWithoutConnectorShouldThrowAnException(): void
@@ -142,7 +142,7 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectErrorMessage('You must specify connector for given pipeline `without-connector`.');
 
-        $this->registry->getPipeline('without-connector');
+        $this->registry->getPipeline('without-connector', 'some');
     }
 
     public function testGetsPipelineWithWrongConnectorShouldThrowAnException(): void
@@ -150,6 +150,6 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectErrorMessage('Connector should implement Spiral\RoadRunner\Jobs\Queue\CreateInfoInterface interface.');
 
-        $this->registry->getPipeline('with-wrong-connector');
+        $this->registry->getPipeline('with-wrong-connector', 'some');
     }
 }

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -22,6 +22,7 @@ abstract class TestCase extends \Spiral\Testing\TestCase
             RoadRunnerBridge\BroadcastingBootloader::class,
             RoadRunnerBridge\RoadRunnerBootloader::class,
             RoadRunnerBridge\TcpBootloader::class,
+            RoadRunnerBridge\MetricsBootloader::class,
 
             // Framework commands
             ConsoleBootloader::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️ 
| New feature?  | ✔️

Added the ability to configure serializers for different types of jobs.

- [x] Waiting PR in SF: https://github.com/spiral/framework/pull/749

Example:
```php
// file app/config/queue.php
<?php

declare(strict_types=1);

return [
    'registry' => [
        'serializers' => [
            \Spiral\Queue\Job\ObjectJob::class => 'json',
            \Spiral\App\Job\TestJob::class => 'serializer'
        ]
    ],
];
```