### PR TITLE
Adding the ability to configure priority and autoAck

### DIFF
--- a/src/Queue/Dispatcher.php
+++ b/src/Queue/Dispatcher.php
@@ -58,7 +58,7 @@ final class Dispatcher implements DispatcherInterface
                         $task = $task->withHeader($header, $values);
                     }
                 }
-                if ($options instanceof OptionsInterface) {
+                if ($options instanceof OptionsInterface && $options->getDelay() !== null) {
                     $task = $task->withDelay($options->getDelay());
                 }
 

--- a/src/Queue/Options.php
+++ b/src/Queue/Options.php
@@ -7,8 +7,42 @@ namespace Spiral\RoadRunnerBridge\Queue;
 use Spiral\Queue\Options as QueueOptions;
 use Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface;
 use Spiral\RoadRunner\Jobs\Task\WritableHeadersTrait;
+use Spiral\RoadRunner\Jobs\OptionsInterface as JobsOptionsInterface;
 
 final class Options extends QueueOptions implements WritableHeadersInterface, OptionsInterface
 {
     use WritableHeadersTrait;
+
+    /**
+     * @var positive-int|0
+     */
+    private int $priority = JobsOptionsInterface::DEFAULT_PRIORITY;
+
+    private bool $autoAck = JobsOptionsInterface::DEFAULT_AUTO_ACK;
+
+    public function withPriority(int $priority): self
+    {
+        $options = clone $this;
+        $options->priority = $priority;
+
+        return $options;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function autoAck(bool $autoAck = true): self
+    {
+        $options = clone $this;
+        $options->autoAck = $autoAck;
+
+        return $options;
+    }
+
+    public function isAutoAck(): bool
+    {
+        return $this->autoAck;
+    }
 }

--- a/src/Queue/Options.php
+++ b/src/Queue/Options.php
@@ -14,7 +14,7 @@ final class Options extends QueueOptions implements WritableHeadersInterface, Op
     use WritableHeadersTrait;
 
     /**
-     * @var positive-int|0
+     * @var 0|positive-int
      */
     private int $priority = JobsOptionsInterface::DEFAULT_PRIORITY;
 

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -78,9 +78,8 @@ final class Queue implements QueueInterface
         return $this->queues[$pipeline] = $registry->getPipeline($pipeline, $jobType);
     }
 
-    private function createJobsOptions(
-        QueueOptionsInterface|ProvidesHeadersInterface|OptionsInterface $options = null
-    ): ?Options {
+    private function createJobsOptions(QueueOptionsInterface|OptionsInterface $options = null): ?Options
+    {
         return match (true) {
             $options instanceof BridgeOptions => new Options(
                 $options->getDelay() ?? Options::DEFAULT_DELAY,

--- a/tests/src/Queue/OptionsTest.php
+++ b/tests/src/Queue/OptionsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Queue;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\RoadRunner\Jobs\OptionsInterface;
+use Spiral\RoadRunnerBridge\Queue\Options;
+
+final class OptionsTest extends TestCase
+{
+    public function testPriority(): void
+    {
+        $options = new Options();
+
+        $this->assertSame(OptionsInterface::DEFAULT_PRIORITY, $options->getPriority());
+        $this->assertSame(5, $options->withPriority(5)->getPriority());
+        $this->assertSame(3, $options->withPriority(3)->getPriority());
+        $this->assertSame(0, $options->withPriority(0)->getPriority());
+    }
+
+    public function testAutoAck(): void
+    {
+        $options = new Options();
+
+        $this->assertSame(OptionsInterface::DEFAULT_AUTO_ACK, $options->isAutoAck());
+        $this->assertSame(true, $options->autoAck()->isAutoAck());
+        $this->assertSame(false, $options->autoAck(false)->isAutoAck());
+    }
+}

--- a/tests/src/Queue/QueueTest.php
+++ b/tests/src/Queue/QueueTest.php
@@ -142,7 +142,7 @@ final class QueueTest extends TestCase
         yield [new JobsOptions(autoAck: true), (new BridgeOptions())->autoAck()];
         yield [
             new JobsOptions(delay: 2, priority: 4, autoAck: true),
-            (new BridgeOptions())->withDelay(2)->withPriority(4)->autoAck()
+            (new BridgeOptions())->withDelay(2)->withPriority(4)->autoAck(),
         ];
     }
 }

--- a/tests/src/Queue/QueueTest.php
+++ b/tests/src/Queue/QueueTest.php
@@ -125,7 +125,6 @@ final class QueueTest extends TestCase
         $this->assertEquals($expected, $ref->invoke($queue, $arguments));
     }
 
-
     public function optionsDataProvider(): \Generator
     {
         // without options


### PR DESCRIPTION
This PR adds the ability to configure the `priority` and `autoAck` parameters in the `Options` from the roadrunner-jobs package:

https://github.com/spiral/roadrunner-jobs/blob/master/src/Options.php#L24
https://github.com/spiral/roadrunner-jobs/blob/master/src/Options.php#L29

Example:
```php
namespace App\Controller;

use App\Job\Ping;
use Spiral\Queue\QueueInterface;
use Spiral\RoadRunnerBridge\Queue\Options;

class HomeController
{
    public function __construct(
        private readonly QueueInterface $queue,
    ) {
    }

    public function ping(): string
    {
        $jobID = $this->queue->push(Ping::class, [
            'value' => 'hello world',
        ], (new Options())->withPriority(4)->autoAck()->withDelay(5));

        return sprintf('Job ID: %s', $jobID);
    }
}
```