### PR TITLE
Add roadrunner logger handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,7 +1027,7 @@ Full example Echo GRPC service you can find [here](https://github.com/spiral/roa
 ------
 
 ### Logger
-Logger provide a simple way to send log messages to RoadRunner.
+Logger provides a simple way to send log messages to RoadRunner.
 
 ## Configuration
 
@@ -1075,7 +1075,6 @@ final class SomeBootloader extends Bootloader
 }
 
 ```
-
 
 ## Usage example
 ```PHP

--- a/README.md
+++ b/README.md
@@ -1049,7 +1049,6 @@ return [
            // or
            new Autowire(Handler::class, ['formatter' => "%message% foo"]),
            // or alias (first, you need to register it)
-           'my-handler'
        ]
    ]
 ];

--- a/README.md
+++ b/README.md
@@ -1058,7 +1058,7 @@ Also you can define a default message format in `.env`
 LOGGER_FORMAT=%message% foo
 ```
 
-Handler registration example in custom bootloader
+Handler registration example in a custom bootloader
 ```PHP
 use Spiral\Boot\Bootloader;
 use Spiral\Monolog\Bootloader\MonologBootloader;

--- a/README.md
+++ b/README.md
@@ -1055,7 +1055,7 @@ return [
 ];
 ```
 
-Also you can define default message format in ```.env```
+Also you can define a default message format in `.env`
 ```dotenv
 LOGGER_FORMAT=%message% foo
 ```

--- a/README.md
+++ b/README.md
@@ -1031,7 +1031,7 @@ Logger provides a simple way to send log messages to RoadRunner.
 
 ## Configuration
 
-Update config file `app/config/monolog.php`:
+You can register `Spiral\RoadRunnerBridge\Logger\Handler` in `app/config/monolog.php` config:
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ protected const LOAD = [
     - [Commands](#console-commands-2)
 - [Logger](#logger)
   - [Configuration](#configuration-5)
+  - [Usage example](#usage-example-5)
 - [Metrics](#metrics)
 
 ### Cache

--- a/README.md
+++ b/README.md
@@ -1074,7 +1074,7 @@ final class SomeBootloader extends Bootloader
 
 ```
 
-## Usage example
+## Usage
 ```PHP
 <?php
 

--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,6 @@ return [
            Handler::class,
            // or
            new Autowire(Handler::class, ['formatter' => "%message% foo"]),
-           // or alias (first, you need to register it)
        ]
    ]
 ];

--- a/README.md
+++ b/README.md
@@ -1044,7 +1044,7 @@ return [
    //...
    
    'handlers' => [
-       'default' => [
+       'roadrunner' => [
            Handler::class,
            // or
            new Autowire(Handler::class, ['formatter' => "%message% foo"]),

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "spiral/roadrunner-broadcast": "^2.0",
     "spiral/roadrunner-tcp": "^2.0",
     "spiral/roadrunner-metrics": "^2.0",
-    "roadrunner-php/app-logger": "dev-master",
+    "roadrunner-php/app-logger": "^1.0",
     "spiral/framework": "^3.2",
     "spiral/serializer": "^3.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "spiral/roadrunner-broadcast": "^2.0",
     "spiral/roadrunner-tcp": "^2.0",
     "spiral/roadrunner-metrics": "^2.0",
+    "roadrunner-php/app-logger": "dev-master",
     "spiral/framework": "^3.2",
     "spiral/serializer": "^3.2"
   },

--- a/src/Bootloader/LoggerBootloader.php
+++ b/src/Bootloader/LoggerBootloader.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\Bootloader;
+
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Monolog\Bootloader\MonologBootloader;
+use RoadRunner\Logger\Logger;
+use Spiral\RoadRunnerBridge\Logger\Handler;
+
+final class LoggerBootloader extends Bootloader
+{
+    protected const DEPENDENCIES = [
+        MonologBootloader::class
+    ];
+
+    protected const SINGLETONS = [
+        Handler::class => [self::class, 'initHandler']
+    ];
+
+    private function initHandler(Logger $logger, EnvironmentInterface $env): Handler
+    {
+        return new Handler($logger, $env->get('LOGGER_FORMAT', Handler::FORMAT));
+    }
+}

--- a/src/Logger/Handler.php
+++ b/src/Logger/Handler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\Logger;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use RoadRunner\Logger\Logger as RoadRunnerLogger;
+
+class Handler extends AbstractProcessingHandler
+{
+    public function __construct(private readonly RoadRunnerLogger $logger)
+    {
+        parent::__construct();
+    }
+
+    protected function write(array $record): void
+    {
+        $message = $record['message'] ?? $record['formatted'];
+
+        switch ($record['level']) {
+            case Logger::ERROR:
+                $this->logger->error($message);
+                break;
+            case Logger::WARNING:
+                $this->logger->warning($message);
+                break;
+            case Logger::INFO:
+                $this->logger->info($message);
+                break;
+            case Logger::DEBUG:
+                $this->logger->debug($message);
+                break;
+            default:
+                $this->logger->log($message);
+        }
+    }
+}

--- a/src/Logger/Handler.php
+++ b/src/Logger/Handler.php
@@ -17,7 +17,7 @@ class Handler extends AbstractProcessingHandler
 
     protected function write(array $record): void
     {
-        $message = $record['message'] ?? $record['formatted'];
+        $message = $record['formatted'];
 
         switch ($record['level']) {
             case Logger::ERROR:

--- a/src/Logger/Handler.php
+++ b/src/Logger/Handler.php
@@ -4,36 +4,38 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunnerBridge\Logger;
 
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use RoadRunner\Logger\Logger as RoadRunnerLogger;
 
 class Handler extends AbstractProcessingHandler
 {
-    public function __construct(private readonly RoadRunnerLogger $logger)
-    {
+    public const FORMAT = "%message% %context% %extra%\n";
+
+    public function __construct(
+        private readonly RoadRunnerLogger $logger,
+        string|FormatterInterface $formatter = self::FORMAT
+    ) {
         parent::__construct();
+
+        if (\is_string($formatter)) {
+            $formatter = new LineFormatter($formatter);
+        }
+
+        $this->setFormatter($formatter);
     }
 
     protected function write(array $record): void
     {
         $message = $record['formatted'];
 
-        switch ($record['level']) {
-            case Logger::ERROR:
-                $this->logger->error($message);
-                break;
-            case Logger::WARNING:
-                $this->logger->warning($message);
-                break;
-            case Logger::INFO:
-                $this->logger->info($message);
-                break;
-            case Logger::DEBUG:
-                $this->logger->debug($message);
-                break;
-            default:
-                $this->logger->log($message);
-        }
+        match ($record['level']) {
+            Logger::ERROR, Logger::CRITICAL => $this->logger->error($message),
+            Logger::WARNING, Logger::ALERT, Logger::EMERGENCY => $this->logger->warning($message),
+            Logger::INFO, Logger::NOTICE => $this->logger->info($message),
+            Logger::DEBUG => $this->logger->debug($message),
+        };
     }
 }

--- a/tests/src/Bootloader/LoggerBootloaderTest.php
+++ b/tests/src/Bootloader/LoggerBootloaderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Bootloader;
+
+use Spiral\RoadRunnerBridge\Logger\Handler;
+use Spiral\Tests\TestCase;
+
+final class LoggerBootloaderTest extends TestCase
+{
+    public function testHandlerBinding(): void
+    {
+        $this->assertContainerBoundAsSingleton(Handler::class, Handler::class);
+    }
+}

--- a/tests/src/Logger/HandlerTest.php
+++ b/tests/src/Logger/HandlerTest.php
@@ -31,10 +31,6 @@ final class HandlerTest extends TestCase
             ),
         ]);
 
-        $this->getContainer()->bind(LoggerInterface::class, $monolog);
-
-        $logger = $this->getContainer()->get(LoggerInterface::class);
-
         $rpc->shouldReceive('call')
             ->once()
             ->with($expectedResult['level'], $expectedResult['message'])
@@ -42,7 +38,7 @@ final class HandlerTest extends TestCase
 
         $method = $input['method'];
 
-        $logger->$method($input['message']);
+        $monolog->$method($input['message']);
     }
 
     public function provideLogData(): array

--- a/tests/src/Logger/HandlerTest.php
+++ b/tests/src/Logger/HandlerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Logger;
+
+use Psr\Log\LoggerInterface;
+use RoadRunner\Logger\Logger;
+use Spiral\Goridge\RPC\RPCInterface;
+use Spiral\RoadRunnerBridge\Logger\Handler;
+use Spiral\Tests\TestCase;
+use Mockery as m;
+use Monolog\Logger as Monolog;
+
+final class HandlerTest extends TestCase
+{
+    /**
+     * @dataProvider provideLogData
+     */
+    public function testSendLog($expectedResult, $input): void
+    {
+        $rpc = m::mock(RPCInterface::class);
+
+        $rpc->shouldReceive('withServicePrefix')->once()->with('app')->andReturnSelf();
+
+        $monolog = new Monolog('default');
+        $monolog->setHandlers([
+            new Handler(
+                new Logger($rpc),
+                "%message% foo"
+            ),
+        ]);
+
+        $this->getContainer()->bind(LoggerInterface::class, $monolog);
+
+        $logger = $this->getContainer()->get(LoggerInterface::class);
+
+        $rpc->shouldReceive('call')
+            ->once()
+            ->with($expectedResult['level'], $expectedResult['message'])
+            ->andReturnSelf();
+
+        $method = $input['method'];
+
+        $logger->$method($input['message']);
+    }
+
+    public function provideLogData(): array
+    {
+        return [
+            [
+                [
+                    'level' => 'Error',
+                    'message' => 'Error message foo',
+                ],
+                [
+                    'method' => 'error',
+                    'message' => 'Error message',
+                ],
+            ],
+            [
+                [
+                    'level' => 'Warning',
+                    'message' => 'Warning message foo',
+                ],
+                [
+                    'method' => 'warning',
+                    'message' => 'Warning message',
+                ],
+            ],
+            [
+                [
+                    'level' => 'Info',
+                    'message' => 'Info message foo',
+                ],
+                [
+                    'method' => 'info',
+                    'message' => 'Info message',
+                ],
+            ],
+            [
+                [
+                    'level' => 'Debug',
+                    'message' => 'Debug message foo',
+                ],
+                [
+                    'method' => 'debug',
+                    'message' => 'Debug message',
+                ],
+            ],
+            [
+                [
+                    'level' => 'Warning',
+                    'message' => 'Emergency message foo',
+                ],
+                [
+                    'method' => 'emergency',
+                    'message' => 'Emergency message',
+                ],
+            ],
+            [
+                [
+                    'level' => 'Warning',
+                    'message' => 'Alert message foo',
+                ],
+                [
+                    'method' => 'alert',
+                    'message' => 'Alert message',
+                ],
+            ],
+            [
+                [
+                    'level' => 'Error',
+                    'message' => 'Critical message foo',
+                ],
+                [
+                    'method' => 'critical',
+                    'message' => 'Critical message',
+                ],
+            ],
+            [
+                [
+                    'level' => 'Info',
+                    'message' => 'Notice message foo',
+                ],
+                [
+                    'method' => 'notice',
+                    'message' => 'Notice message',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -23,6 +23,7 @@ abstract class TestCase extends \Spiral\Testing\TestCase
             RoadRunnerBridge\RoadRunnerBootloader::class,
             RoadRunnerBridge\TcpBootloader::class,
             RoadRunnerBridge\MetricsBootloader::class,
+            RoadRunnerBridge\LoggerBootloader::class,
 
             // Framework commands
             ConsoleBootloader::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | ✔️

Added RoadRunner logger handler

// First, you need to register ```LoggerBootloader``` in ```App.php```
```PHP
use Spiral\RoadRunnerBridge\Bootloader\LoggerBootloader;

protected const LOAD = [
     // ...
     LoggerBootloader::class
];
```

Handler registration example
```PHP
use Spiral\Boot\Bootloader;
use Spiral\Monolog\Bootloader\MonologBootloader;
use Spiral\RoadRunnerBridge\Logger\Handler;

final class SomeBootloader extends Bootloader
{
    public function init(MonologBootloader $monolog, Handler $handler): void 
    {
        $monolog->addHandler($handler);
    }
}

```

Usage example
```PHP
use Psr\Log\LoggerInterface;
use Spiral\Router\Annotation\Route;

class HomeController
{
    #[Route(route: '/', name: 'home', methods: ['GET'])]
    public function index(LoggerInterface $logger): string
    {
        $logger->warning('Warning message');
        $logger->error('Error message');
        $logger->debug('Debug message');
        $logger->critical("Critical message");
        $logger->info('Info message');
        $logger->emergency("Emergency message");
    }
}
```
// In RoadRunner...
![image](https://user-images.githubusercontent.com/44509066/199532199-deba73a9-fca7-4098-afe1-0cb1fc1bf897.png)

`config/monolog.php` example
```PHP
use Spiral\RoadRunnerBridge\Logger\Handler;

return [
   'handlers' => [
       'default' => [
           Handler::class,
           // or
           new Autowire(Handler::class, ['formatter' => "%message% foo"]),
           // or
           'my-handler'
       ]
   ]
];
```

You can define default message format in ```.env```
```
LOGGER_FORMAT="%message% foo"
```