### PR TITLE
Add generatedPath and servicesBasePath to GRPC config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ use Spiral\Cache\Storage\FileStorage;
 return [
 
     'default' => 'array',
-    
+
     /**
      *  Aliases for storages, if you want to use domain specific storages
      */
@@ -104,7 +104,7 @@ return [
             // Alias for ArrayStorage type
             'type' => 'array',
         ],
-        
+
         'localMemory' => [
             'type' => ArrayStorage::class,
         ],
@@ -114,7 +114,7 @@ return [
             'type' => 'file',
             'path' => __DIR__.'/../../runtime/cache',
         ],
-        
+
     ],
 
     /**
@@ -143,8 +143,8 @@ class MyService {
 
     private CacheInterface $cache;
     private PostReposiory $posts;
-    
-    public function __construct(CacheInterface $cache, PostReposiory $posts) 
+
+    public function __construct(CacheInterface $cache, PostReposiory $posts)
     {
         $this->cache = $cache;
         $this->posts = $posts;
@@ -154,7 +154,7 @@ class MyService {
     {
         $posts = $this->posts->findAll();
         $this->cache->set('posts', $posts);
-        
+
         // ...
     }
 }
@@ -174,8 +174,8 @@ class MyService {
 
     private CacheStorageProviderInterface $cacheManager;
     private PostReposiory $posts;
-    
-    public function __construct(CacheStorageProviderInterface $cacheManager, PostReposiory $posts) 
+
+    public function __construct(CacheStorageProviderInterface $cacheManager, PostReposiory $posts)
     {
         $this->cacheManager = $cacheManager;
         $this->posts = $posts;
@@ -185,10 +185,10 @@ class MyService {
     {
         /** @var \Psr\SimpleCache\CacheInterface $cache */
         $cache = $this->cacheManager->storage('inMemory');
-        
+
         $posts = $this->posts->findAll();
         $this->cache->set('posts', $posts);
-        
+
         // ...
     }
 }
@@ -218,8 +218,8 @@ class MyService {
 
     private CacheStorageProviderInterface $cacheManager;
     private PostReposiory $posts;
-    
-    public function __construct(CacheStorageProviderInterface $cacheManager, UserRepository $posts) 
+
+    public function __construct(CacheStorageProviderInterface $cacheManager, UserRepository $posts)
     {
         $this->cacheManager = $cacheManager;
         $this->posts = $posts;
@@ -229,7 +229,7 @@ class MyService {
     {
         /** @var \Psr\SimpleCache\CacheInterface $cache */
         $cache = $this->cacheManager->storage('user-data');
-        
+
         // ...
     }
 }
@@ -245,8 +245,8 @@ There are two ways to add cache storages:
 final class DatabaseStorage implements \Psr\SimpleCache\CacheInterface
 {
     private string $table;
-    
-    public function __construct(string $table) 
+
+    public function __construct(string $table)
     {
         $this->table = $table;
     }
@@ -314,7 +314,7 @@ return [
         // 'mail-queue' => 'roadrunner',
         // 'rating-queue' => 'sync',
     ],
-    
+
     /**
      * Queue connections
      * Drivers: "sync", "roadrunner"
@@ -333,32 +333,32 @@ return [
                     // Run consumer for this pipeline on startup (by default)
                     // You can pause consumer for this pipeline via console command
                     // php app.php queue:pause local
-                    'consume' => true 
+                    'consume' => true
                 ],
                 // 'amqp' => [
                 //     'connector' => new AMQPCreateInfo('bus', ...),
                 //     // Don't consume jobs for this pipeline on start
                 //     // You can run consumer for this pipeline via console command
                 //     // php app.php queue:resume local
-                //     'consume' => false 
+                //     'consume' => false
                 // ],
-                // 
+                //
                 // 'beanstalk' => [
                 //     'connector' => new BeanstalkCreateInfo('bus', ...),
                 // ],
-                // 
+                //
                 // 'sqs' => [
                 //     'connector' => new SQSCreateInfo('amazon', ...),
                 // ],
             ]
         ],
     ],
-    
+
     'driverAliases' => [
         'sync' => \Spiral\Queue\Driver\SyncDriver::class,
         'roadrunner' => \Spiral\RoadRunnerBridge\Queue\Queue::class,
     ],
-    
+
     'registry' => [
         'handlers' => [],
         'serializers' => [
@@ -403,12 +403,12 @@ class MyService {
 
     private ContainerInterface $container;
     private  QueueInterface $queue;
-    
+
     /**
      * @param QueueInterface $queue - Default queue will be injected
      * @param ContainerInterface $container
      */
-    public function __construct(QueueInterface $queue, ContainerInterface $container) 
+    public function __construct(QueueInterface $queue, ContainerInterface $container)
     {
         $this->container = $container;
         $this->queue = $queue;
@@ -417,13 +417,13 @@ class MyService {
     public function handle()
     {
         $queue = $this->queue;
-        
-        // OR gets queue from manager 
+
+        // OR gets queue from manager
 
         /** @var QueueManager $queueManager */
         $queueManager = $this->container->get(QueueConnectionProviderInterface::class);
         $queue = $queueManager->getConnection('sync');
-        
+
         $queue->push(PingHandler::class, ['url' => 'https://google.com']);
     }
 }
@@ -444,7 +444,7 @@ $queue->push('ping', ['url' => 'https://google.com']);
 
 #### Job serializer
 
-You can configure a specific serializer for a particular job. Add a job as a key with the desired serializer as a value 
+You can configure a specific serializer for a particular job. Add a job as a key with the desired serializer as a value
 in the `app/config/queue.php` configuration file:
 
 ```php
@@ -462,8 +462,8 @@ return [
 ];
 ```
 
-The serializer can be a string key from the `Spiral\Serializer\SerializerRegistry`. The fully qualified name of the serializer class, 
-serializer instance, `Spiral\Core\Container\Autowire` instance. 
+The serializer can be a string key from the `Spiral\Serializer\SerializerRegistry`. The fully qualified name of the serializer class,
+serializer instance, `Spiral\Core\Container\Autowire` instance.
 The serializer class must implement the `Spiral\Serializer\SerializerInterface`.
 
 #### Job DTO's
@@ -478,12 +478,12 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class Ping
 {
     private string $url;
-    
-    public function __construct(string $url) 
+
+    public function __construct(string $url)
     {
         $this->url = $url;
     }
-    
+
     public function __invoke(HttpClientInterface $client): void
     {
         $status = $client->request('GET', $this->url)->getStatusCode() === 200;
@@ -498,8 +498,8 @@ use Spiral\Queue\QueueInterface;
 class MyService {
 
     private QueueInterface $queue;
-    
-    public function __construct(QueueInterface $queue) 
+
+    public function __construct(QueueInterface $queue)
     {
         $this->queue = $queue;
     }
@@ -532,8 +532,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class MyService {
 
     private QueueInterface $queue;
-    
-    public function __construct(QueueConnectionProviderInterface $manager) 
+
+    public function __construct(QueueConnectionProviderInterface $manager)
     {
         $this->queue = $manager->getConnection('user-data');
     }
@@ -573,7 +573,7 @@ class DatabaseFailedJobsHandler implements FailedJobHandlerInterface
 {
     private DatabaseInterface $database;
     private SerializerInterface $serializer;
-    
+
     public function __construct(DatabaseInterface $database, SerializerInterface $serializer)
     {
         $this->database = $database;
@@ -620,7 +620,7 @@ protected const LOAD = [
     RoadRunnerBridge\QueueBootloader::class,
     App\Bootloader\QueueFailedJobsBootloader::class,
     RoadRunnerBridge\CommandBootloader::class,
-    
+
     // ...
 ];
 ```
@@ -641,7 +641,7 @@ protected const LOAD = [
 'memory' => [
     'driver' => 'roadrunner',
     'connector' => new MemoryCreateInfo('local'),
-    'consume' => true // Consume jobs 
+    'consume' => true // Consume jobs
 ],
 ```
 
@@ -665,7 +665,7 @@ use Spiral\RoadRunnerBridge\Bootloader as RoadRunnerBridge;
 
 protected const LOAD = [
     // ...
-    RoadRunnerBridge\TcpBootloader::class, 
+    RoadRunnerBridge\TcpBootloader::class,
     // ...
 ];
 ```
@@ -714,17 +714,17 @@ return [
 
     /**
      * Interceptors, this section is optional.
-     * @see https://spiral.dev/docs/cookbook-domain-core/2.8/en#core-interceptors  
+     * @see https://spiral.dev/docs/cookbook-domain-core/2.8/en#core-interceptors
      */
     'interceptors' => [
         // several interceptors
         'smtp' => [
-            SomeInterceptor::class, 
+            SomeInterceptor::class,
             OtherInterceptor::class
         ],
-        'monolog' => SomeInterceptor::class // one interceptor 
+        'monolog' => SomeInterceptor::class // one interceptor
     ],
-    
+
     'debug' => env('TCP_DEBUG', false)
 ];
 ```
@@ -756,7 +756,7 @@ class TestService implements ServiceInterface
     public function handle(Request $request): ResponseInterface
     {
         // some logic
-    
+
         return new RespondMessage('some message', true);
     }
 }
@@ -846,12 +846,12 @@ broadcast:
 ```php
 use Spiral\Broadcasting\BroadcastInterface;
 
-final class SendVerificationLink 
+final class SendVerificationLink
 {
     private BroadcastInterface $broadcast;
     private UserReposiory $users;
     private VerificationLinkGenerator $linkGenerator;
-    
+
     public function __construct(
         BroadcastInterface $broadcast,
         UserReposiory $users,
@@ -865,11 +865,11 @@ final class SendVerificationLink
     public function handle(int $userId): void
     {
         $user = $this->users->findByPK($userId);
-        
+
         // ...
-        
+
         $this->broadcast->publish(
-            'user.{$user->id}', 
+            'user.{$user->id}',
             \sprintf('Your verification link is: %s', $this->linkGenerator->getLink($user))
         );
     }
@@ -881,12 +881,12 @@ final class SendVerificationLink
 ```php
 use Spiral\Broadcasting\BroadcastManagerInterface;
 
-final class SendVerificationLink 
+final class SendVerificationLink
 {
     private BroadcastManagerInterface $broadcastManager;
     private UserReposiory $users;
     private VerificationLinkGenerator $linkGenerator;
-    
+
     public function __construct(
         BroadcastManagerInterface $broadcastManager,
         UserReposiory $users,
@@ -900,7 +900,7 @@ final class SendVerificationLink
     public function handle(int $userId): void
     {
         $broadcast = $this->broadcastManager->connection('log');
-        
+
         // ...
     }
 }
@@ -928,10 +928,28 @@ declare(strict_types=1);
 return [
     /**
      * Path to protoc-gen-php-grpc library.
-     * Default: null 
+     * Default: null
      */
     'binaryPath' => null,
     // 'binaryPath' => __DIR__.'/../../protoc-gen-php-grpc',
+
+    /**
+     * Path to proto directory, where generated files put
+     * Default: null
+     */
+    'generatedPath' => null,
+
+    /**
+     * Proto file namespace
+     * Default: null
+     */
+    'namespace' => null,
+
+    /**
+     * Base path, root for all proto files
+     * Default: null
+     */
+    'servicesBasePath' => null
 
     'services' => [
         __DIR__.'/../../proto/echo.proto',
@@ -1042,7 +1060,7 @@ use Spiral\RoadRunnerBridge\Logger\Handler;
 
 return [
    //...
-   
+
    'handlers' => [
        'roadrunner' => [
            Handler::class,
@@ -1066,7 +1084,7 @@ use Spiral\RoadRunnerBridge\Logger\Handler;
 
 final class SomeBootloader extends Bootloader
 {
-    public function init(MonologBootloader $monolog, Handler $handler): void 
+    public function init(MonologBootloader $monolog, Handler $handler): void
     {
         $monolog->addHandler($handler);
     }
@@ -1199,7 +1217,7 @@ class AppBootloader extends Bootloader
 To populate metric from application use `Spiral\RoadRunner\Metrics\MetricsInterface`:
 
 ```php
-use Spiral\RoadRunner\Metrics\MetricsInterface; 
+use Spiral\RoadRunner\Metrics\MetricsInterface;
 
 // ...
 
@@ -1246,7 +1264,7 @@ class MetricsBootloader extends Bootloader
 You should specify values for your labels while pushing the metric:
 
 ```php
-use Spiral\RoadRunner\MetricsInterface; 
+use Spiral\RoadRunner\MetricsInterface;
 
 // ...
 

--- a/README.md
+++ b/README.md
@@ -946,7 +946,7 @@ return [
     'namespace' => null,
 
     /**
-     * Base path, root for all proto files
+     * Base path for all proto files
      * Default: null
      */
     'servicesBasePath' => null

--- a/README.md
+++ b/README.md
@@ -934,19 +934,19 @@ return [
     // 'binaryPath' => __DIR__.'/../../protoc-gen-php-grpc',
 
     /**
-     * Path to proto directory, where generated files put
+     * Path, where generated DTO files put.
      * Default: null
      */
     'generatedPath' => null,
 
     /**
-     * Proto file namespace
+     * Base namespace for generated proto files.
      * Default: null
      */
     'namespace' => null,
 
     /**
-     * Base path for all proto files
+     * Root path for all proto files in which imports will be searched.
      * Default: null
      */
     'servicesBasePath' => null

--- a/README.md
+++ b/README.md
@@ -965,10 +965,10 @@ php app.php grpc:generate
 
 #### Console commands
 
-| Command                                    | Description                                             |
-|--------------------------------------------|---------------------------------------------------------|
-| grpc:services                              | List available GRPC services                            |
-| grpc:generate {path=auto} {namespace=auto} | Generate GPRC service code using protobuf specification |
+| Command                                    | Description                                                                                                                                                         |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| grpc:services                              | List available GRPC services                                                                                                                                        |
+| grpc:generate {path=auto} {namespace=auto} | Generate GPRC service code using protobuf specification. By default `path` and `namespace` options is `auto`, will use the values from config for generating files. |
 
 #### Example GRPC service
 

--- a/README.md
+++ b/README.md
@@ -965,10 +965,10 @@ php app.php grpc:generate
 
 #### Console commands
 
-| Command                                    | Description                                                                                                                                                         |
-|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| grpc:services                              | List available GRPC services                                                                                                                                        |
-| grpc:generate {path=auto} {namespace=auto} | Generate GPRC service code using protobuf specification. By default `path` and `namespace` options is `auto`, will use the values from config for generating files. |
+| Command                                    | Description                                                                                                                                                                        |
+|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| grpc:services                              | List available GRPC services                                                                                                                                                       |
+| grpc:generate {path=auto} {namespace=auto} | Generate GPRC service code using protobuf specification. By default `path` and `namespace` options are `auto`. Defined values from config will be used in `auto` mode, by default. |
 
 #### Example GRPC service
 

--- a/src/Bootloader/GRPCBootloader.php
+++ b/src/Bootloader/GRPCBootloader.php
@@ -60,6 +60,10 @@ final class GRPCBootloader extends Bootloader
                  */
                 'binaryPath' => null,
 
+                'generatedPath' => null,
+                'namespace' => null,
+                'servicesBasePath' => null,
+
                 'services' => [],
 
                 'interceptors' => [],

--- a/src/Config/GRPCConfig.php
+++ b/src/Config/GRPCConfig.php
@@ -27,16 +27,25 @@ final class GRPCConfig extends InjectableConfig
         return $this->config['binaryPath'] ?? null;
     }
 
+    /**
+     * Get proto directory path, where generated files put
+     */
     public function getGeneratedPath(): ?string
     {
         return $this->config['generatedPath'] ?? null;
     }
 
+    /**
+     * Get proto file namespace
+     */
     public function getNamespace(): ?string
     {
         return $this->config['namespace'] ?? null;
     }
 
+    /**
+     * Get proto files base path
+     */
     public function getServicesBasePath(): ?string
     {
         return $this->config['servicesBasePath'] ?? null;

--- a/src/Config/GRPCConfig.php
+++ b/src/Config/GRPCConfig.php
@@ -44,7 +44,7 @@ final class GRPCConfig extends InjectableConfig
     }
 
     /**
-     * Get proto files base path
+     * Root path for all proto files in which imports will be searched.
      */
     public function getServicesBasePath(): ?string
     {

--- a/src/Config/GRPCConfig.php
+++ b/src/Config/GRPCConfig.php
@@ -28,7 +28,7 @@ final class GRPCConfig extends InjectableConfig
     }
 
     /**
-     * Get proto directory path, where generated files put
+     * Path, where generated DTO files put.
      */
     public function getGeneratedPath(): ?string
     {

--- a/src/Config/GRPCConfig.php
+++ b/src/Config/GRPCConfig.php
@@ -36,7 +36,7 @@ final class GRPCConfig extends InjectableConfig
     }
 
     /**
-     * Get proto file namespace
+     * Base namespace for generated proto files.
      */
     public function getNamespace(): ?string
     {

--- a/src/Config/GRPCConfig.php
+++ b/src/Config/GRPCConfig.php
@@ -11,9 +11,32 @@ final class GRPCConfig extends InjectableConfig
 {
     public const CONFIG = 'grpc';
 
+    protected array $config = [
+        'binaryPath' => null,
+        'generatedPath' => null,
+        'namespace' => null,
+        'servicesBasePath' => null,
+        'services' => [],
+    ];
+
     public function getBinaryPath(): ?string
     {
         return $this->config['binaryPath'] ?? null;
+    }
+
+    public function getGeneratedPath(): ?string
+    {
+        return $this->config['generatedPath'] ?? null;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->config['namespace'] ?? null;
+    }
+
+    public function getServicesBasePath(): ?string
+    {
+        return $this->config['servicesBasePath'] ?? null;
     }
 
     /**

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -92,8 +92,9 @@ final class GenerateCommand extends Command
             return $path;
         }
 
-        if ($config->getGeneratedPath() !== null) {
-            return $config->getGeneratedPath();
+        $generatedPath = $config->getGeneratedPath();
+        if ($generatedPath !== null) {
+            return $generatedPath;
         }
 
         $r = new \ReflectionObject($kernel);
@@ -111,8 +112,9 @@ final class GenerateCommand extends Command
             return $namespace;
         }
 
-        if ($config->getNamespace() !== null) {
-            return $config->getNamespace();
+        $namespace = $config->getNamespace();
+        if ($namespace !== null) {
+            return $namespace;
         }
 
         return (new \ReflectionObject($kernel))->getNamespaceName();

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -29,7 +29,10 @@ final class GenerateCommand extends Command
         $binaryPath = $config->getBinaryPath();
 
         if ($binaryPath !== null && !\file_exists($binaryPath)) {
-            $this->sprintf('<error>Protoc plugin binary `%s` was not found.  Use command `./vendor/bin/rr download` to download it.`</error>', $binaryPath);
+            $this->sprintf(
+                '<error>Protoc plugin binary `%s` was not found.  Use command `./vendor/bin/rr download` to download it.`</error>',
+                $binaryPath
+            );
 
             return self::FAILURE;
         }

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -10,6 +10,7 @@ use Spiral\Boot\KernelInterface;
 use Spiral\Console\Command;
 use Spiral\Files\FilesInterface;
 use Spiral\RoadRunnerBridge\Config\GRPCConfig;
+use Spiral\RoadRunnerBridge\GRPC\CommandExecutor;
 use Spiral\RoadRunnerBridge\GRPC\Exception\CompileException;
 use Spiral\RoadRunnerBridge\GRPC\ProtocCommandBuilder;
 use Spiral\RoadRunnerBridge\GRPC\ProtoCompiler;
@@ -43,6 +44,7 @@ final class GenerateCommand extends Command
             $this->getNamespace($kernel, $config->getNamespace()),
             $files,
             new ProtocCommandBuilder($files, $config, $binaryPath),
+            new CommandExecutor()
         );
 
         foreach ($config->getServices() as $protoFile) {

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -90,8 +90,8 @@ final class GenerateCommand extends Command
             return $path;
         }
 
-        if ($generated = $config->getGeneratedPath()) {
-            return $generated;
+        if ($config->getGeneratedPath() !== null) {
+            return $config->getGeneratedPath();
         }
 
         $r = new \ReflectionObject($kernel);
@@ -109,7 +109,7 @@ final class GenerateCommand extends Command
             return $namespace;
         }
 
-        if ($namespace = $config->getNamespace()) {
+        if ($config->getNamespace() !== null) {
             return $namespace;
         }
 

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -30,7 +30,7 @@ final class GenerateCommand extends Command
 
         if ($binaryPath !== null && !\file_exists($binaryPath)) {
             $this->sprintf(
-                '<error>Protoc plugin binary `%s` was not found.  Use command `./vendor/bin/rr download` to download it.`</error>',
+                '<error>Protoc plugin binary `%s` was not found.  Use command `./vendor/bin/rr download-protoc-binary` to download it.`</error>',
                 $binaryPath
             );
 

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -110,7 +110,7 @@ final class GenerateCommand extends Command
         }
 
         if ($config->getNamespace() !== null) {
-            return $namespace;
+            return $config->getNamespace();
         }
 
         return (new \ReflectionObject($kernel))->getNamespaceName();

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -11,6 +11,7 @@ use Spiral\Console\Command;
 use Spiral\Files\FilesInterface;
 use Spiral\RoadRunnerBridge\Config\GRPCConfig;
 use Spiral\RoadRunnerBridge\GRPC\Exception\CompileException;
+use Spiral\RoadRunnerBridge\GRPC\ProtocCommandBuilder;
 use Spiral\RoadRunnerBridge\GRPC\ProtoCompiler;
 
 final class GenerateCommand extends Command
@@ -24,7 +25,8 @@ final class GenerateCommand extends Command
         KernelInterface $kernel,
         FilesInterface $files,
         DirectoriesInterface $dirs,
-        GRPCConfig $config
+        GRPCConfig $config,
+        ProtocCommandBuilder $commandBuilder
     ): int {
         $binaryPath = $config->getBinaryPath();
 
@@ -41,8 +43,8 @@ final class GenerateCommand extends Command
             $this->getPath($kernel, $config),
             $this->getNamespace($kernel, $config),
             $files,
-            $binaryPath,
-            $config->getServicesBasePath(),
+            $commandBuilder,
+            $binaryPath
         );
 
         foreach ($config->getServices() as $protoFile) {

--- a/src/GRPC/CommandExecutor.php
+++ b/src/GRPC/CommandExecutor.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\GRPC;
+
+use Spiral\RoadRunnerBridge\GRPC\Exception\CompileException;
+
+/**
+ * @internal
+ */
+final class CommandExecutor
+{
+    public function execute(string $command): string
+    {
+        \exec(
+            $command,
+            $output,
+            $exitCode
+        );
+
+        if ($exitCode !== 0) {
+            throw new CompileException(\implode("\n", $output), $exitCode);
+        }
+
+        return \trim(\implode("\n", $output), "\n ,");
+    }
+}

--- a/src/GRPC/ProtoCompiler.php
+++ b/src/GRPC/ProtoCompiler.php
@@ -20,7 +20,8 @@ final class ProtoCompiler
         private readonly string $basePath,
         string $baseNamespace,
         private readonly FilesInterface $files,
-        private readonly ProtocCommandBuilder $commandBuilder
+        private readonly ProtocCommandBuilder $commandBuilder,
+        private readonly CommandExecutor $executor
     ) {
         $this->baseNamespace = \str_replace('\\', '/', \rtrim($baseNamespace, '\\'));
     }
@@ -32,17 +33,9 @@ final class ProtoCompiler
     {
         $tmpDir = $this->tmpDir();
 
-        \exec(
-            $this->commandBuilder->build($protoFile, $tmpDir),
-            $output,
-            $exitCode
+        $output = $this->executor->execute(
+            $this->commandBuilder->build(\dirname($protoFile), $tmpDir)
         );
-
-        if ($exitCode !== 0) {
-            throw new CompileException(\implode("\n", $output), $exitCode);
-        }
-
-        $output = \trim(\implode("\n", $output), "\n ,");
 
         if ($output !== '') {
             $this->files->deleteDirectory($tmpDir);

--- a/src/GRPC/ProtoCompiler.php
+++ b/src/GRPC/ProtoCompiler.php
@@ -9,6 +9,8 @@ use Spiral\RoadRunnerBridge\GRPC\Exception\CompileException;
 
 /**
  * Compiles GRPC protobuf declaration and moves files into proper location.
+ *
+ * @internal
  */
 final class ProtoCompiler
 {

--- a/src/GRPC/ProtoCompiler.php
+++ b/src/GRPC/ProtoCompiler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Spiral\RoadRunnerBridge\GRPC;
 
 use Spiral\Files\FilesInterface;
-use Spiral\RoadRunnerBridge\Config\GRPCConfig;
 use Spiral\RoadRunnerBridge\GRPC\Exception\CompileException;
 
 /**

--- a/src/GRPC/ProtoCompiler.php
+++ b/src/GRPC/ProtoCompiler.php
@@ -18,8 +18,7 @@ final class ProtoCompiler
         private readonly string $basePath,
         string $baseNamespace,
         private readonly FilesInterface $files,
-        private readonly ProtocCommandBuilder $commandBuilder,
-        private readonly ?string $protocBinaryPath = null,
+        private readonly ProtocCommandBuilder $commandBuilder
     ) {
         $this->baseNamespace = \str_replace('\\', '/', \rtrim($baseNamespace, '\\'));
     }
@@ -32,7 +31,7 @@ final class ProtoCompiler
         $tmpDir = $this->tmpDir();
 
         \exec(
-            $this->commandBuilder->build($protoFile, $tmpDir, $this->protocBinaryPath),
+            $this->commandBuilder->build($protoFile, $tmpDir),
             $output,
             $exitCode
         );

--- a/src/GRPC/ProtocCommandBuilder.php
+++ b/src/GRPC/ProtocCommandBuilder.php
@@ -7,17 +7,23 @@ namespace Spiral\RoadRunnerBridge\GRPC;
 use Spiral\Files\FilesInterface;
 use Spiral\RoadRunnerBridge\Config\GRPCConfig;
 
-class ProtocCommandBuilder
+/**
+ * @internal
+ */
+final class ProtocCommandBuilder
 {
-    public function __construct(private readonly FilesInterface $files, private readonly GRPCConfig $config)
-    {
+    public function __construct(
+        private readonly FilesInterface $files,
+        private readonly GRPCConfig $config,
+        private readonly string $protocBinaryPath
+    ) {
     }
 
-    public function build(string $protoFile, string $tmpDir, ?string $protocBinaryPath): string
+    public function build(string $protoFile, string $tmpDir): string
     {
         return \sprintf(
             'protoc %s --php_out=%s --php-grpc_out=%s -I=%s -I=%s %s 2>&1',
-            $protocBinaryPath ? '--plugin=' . $protocBinaryPath : '',
+            $this->protocBinaryPath ? '--plugin=' . $this->protocBinaryPath : '',
             \escapeshellarg($tmpDir),
             \escapeshellarg($tmpDir),
             \escapeshellarg($this->config->getServicesBasePath()),
@@ -33,7 +39,7 @@ class ProtocCommandBuilder
     {
         return \array_filter(
             $this->files->getFiles(\dirname($protoFile)),
-            static fn (string $file) => str_contains($file, '.proto')
+            static fn(string $file) => \str_ends_with($file, '.proto')
         );
     }
 }

--- a/src/GRPC/ProtocCommandBuilder.php
+++ b/src/GRPC/ProtocCommandBuilder.php
@@ -21,13 +21,19 @@ final class ProtocCommandBuilder
 
     public function build(string $protoDir, string $tmpDir): string
     {
+        $dirs = \array_filter([
+            $this->config->getServicesBasePath(),
+            $protoDir
+        ]);
+
+        $dirs = $dirs !== [] ? ' -I=' . \implode(' -I=', \array_map('escapeshellarg', $dirs)) : '';
+
         return \sprintf(
-            'protoc %s --php_out=%s --php-grpc_out=%s -I=%s -I=%s %s 2>&1',
+            'protoc %s --php_out=%s --php-grpc_out=%s%s %s 2>&1',
             $this->protocBinaryPath ? '--plugin=' . $this->protocBinaryPath : '',
             \escapeshellarg($tmpDir),
             \escapeshellarg($tmpDir),
-            \escapeshellarg($this->config->getServicesBasePath()),
-            \escapeshellarg(dirname($protoDir)),
+            $dirs,
             \implode(' ', \array_map('escapeshellarg', $this->getProtoFiles($protoDir)))
         );
     }
@@ -38,7 +44,7 @@ final class ProtocCommandBuilder
     private function getProtoFiles(string $protoDir): array
     {
         return \array_filter(
-            $this->files->getFiles(\dirname($protoDir)),
+            $this->files->getFiles($protoDir),
             static fn(string $file) => \str_ends_with($file, '.proto')
         );
     }

--- a/src/GRPC/ProtocCommandBuilder.php
+++ b/src/GRPC/ProtocCommandBuilder.php
@@ -21,19 +21,12 @@ final class ProtocCommandBuilder
 
     public function build(string $protoDir, string $tmpDir): string
     {
-        $dirs = \array_filter([
-            $this->config->getServicesBasePath(),
-            $protoDir
-        ]);
-
-        $dirs = $dirs !== [] ? ' -I=' . \implode(' -I=', \array_map('escapeshellarg', $dirs)) : '';
-
         return \sprintf(
             'protoc %s --php_out=%s --php-grpc_out=%s%s %s 2>&1',
             $this->protocBinaryPath ? '--plugin=' . $this->protocBinaryPath : '',
             \escapeshellarg($tmpDir),
             \escapeshellarg($tmpDir),
-            $dirs,
+            $this->buildDirs($protoDir),
             \implode(' ', \array_map('escapeshellarg', $this->getProtoFiles($protoDir)))
         );
     }
@@ -47,5 +40,19 @@ final class ProtocCommandBuilder
             $this->files->getFiles($protoDir),
             static fn(string $file) => \str_ends_with($file, '.proto')
         );
+    }
+
+    private function buildDirs(string $protoDir): string
+    {
+        $dirs = \array_filter([
+            $this->config->getServicesBasePath(),
+            $protoDir,
+        ]);
+
+        if ($dirs === []) {
+            return '';
+        }
+
+        return ' -I=' . \implode(' -I=', \array_map('escapeshellarg', $dirs));
     }
 }

--- a/src/GRPC/ProtocCommandBuilder.php
+++ b/src/GRPC/ProtocCommandBuilder.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\GRPC;
+
+use Spiral\Files\FilesInterface;
+use Spiral\RoadRunnerBridge\Config\GRPCConfig;
+
+class ProtocCommandBuilder
+{
+    public function __construct(private readonly FilesInterface $files, private readonly GRPCConfig $config)
+    {
+    }
+
+    public function build(string $protoFile, string $tmpDir, ?string $protocBinaryPath): string
+    {
+        return \sprintf(
+            'protoc %s --php_out=%s --php-grpc_out=%s -I=%s -I=%s %s 2>&1',
+            $protocBinaryPath ? '--plugin=' . $protocBinaryPath : '',
+            \escapeshellarg($tmpDir),
+            \escapeshellarg($tmpDir),
+            \escapeshellarg($this->config->getServicesBasePath()),
+            \escapeshellarg(dirname($protoFile)),
+            \implode(' ', \array_map('escapeshellarg', $this->getProtoFiles($protoFile)))
+        );
+    }
+
+    /**
+     * Include all proto files from the directory.
+     */
+    private function getProtoFiles(string $protoFile): array
+    {
+        return \array_filter(
+            $this->files->getFiles(\dirname($protoFile)),
+            static fn (string $file) => str_contains($file, '.proto')
+        );
+    }
+}

--- a/src/GRPC/ProtocCommandBuilder.php
+++ b/src/GRPC/ProtocCommandBuilder.php
@@ -19,7 +19,7 @@ final class ProtocCommandBuilder
     ) {
     }
 
-    public function build(string $protoFile, string $tmpDir): string
+    public function build(string $protoDir, string $tmpDir): string
     {
         return \sprintf(
             'protoc %s --php_out=%s --php-grpc_out=%s -I=%s -I=%s %s 2>&1',
@@ -27,18 +27,18 @@ final class ProtocCommandBuilder
             \escapeshellarg($tmpDir),
             \escapeshellarg($tmpDir),
             \escapeshellarg($this->config->getServicesBasePath()),
-            \escapeshellarg(dirname($protoFile)),
-            \implode(' ', \array_map('escapeshellarg', $this->getProtoFiles($protoFile)))
+            \escapeshellarg(dirname($protoDir)),
+            \implode(' ', \array_map('escapeshellarg', $this->getProtoFiles($protoDir)))
         );
     }
 
     /**
      * Include all proto files from the directory.
      */
-    private function getProtoFiles(string $protoFile): array
+    private function getProtoFiles(string $protoDir): array
     {
         return \array_filter(
-            $this->files->getFiles(\dirname($protoFile)),
+            $this->files->getFiles(\dirname($protoDir)),
             static fn(string $file) => \str_ends_with($file, '.proto')
         );
     }

--- a/tests/app/config/grpc.php
+++ b/tests/app/config/grpc.php
@@ -9,6 +9,10 @@ return [
      */
     'binaryPath' => directory('app') . '../protoc-gen-php-grpc',
 
+    'generatedPath' => null,
+    'namespace' => null,
+    'servicesBasePath' => directory('app') . 'proto',
+
     'services' => [
         directory('app') . 'proto/echo.proto',
         directory('app') . 'proto/foo.proto',

--- a/tests/src/Bootloader/GRPCBootloaderTest.php
+++ b/tests/src/Bootloader/GRPCBootloaderTest.php
@@ -63,6 +63,9 @@ final class GRPCBootloaderTest extends TestCase
 
         $this->assertSame([
             'binaryPath' => $this->getDirectoryByAlias('app') . '../protoc-gen-php-grpc',
+            'generatedPath' => null,
+            'namespace' => null,
+            'servicesBasePath' => $this->getDirectoryByAlias('app') . 'proto',
             'services' => [
                 $this->getDirectoryByAlias('app') . 'proto/echo.proto',
                 $this->getDirectoryByAlias('app') . 'proto/foo.proto',

--- a/tests/src/Config/GRPCConfigTest.php
+++ b/tests/src/Config/GRPCConfigTest.php
@@ -40,4 +40,52 @@ final class GRPCConfigTest extends TestCase
 
         $this->assertSame([], $config->getServices());
     }
+    
+    public function testGetGeneratedPath(): void
+    {
+        $config = new GRPCConfig([
+            'generatedPath' => 'foo',
+        ]);
+
+        $this->assertSame('foo', $config->getGeneratedPath());
+    }
+
+    public function testGetNonExistsGeneratedPath(): void
+    {
+        $config = new GRPCConfig();
+
+        $this->assertNull($config->getGeneratedPath());
+    }
+
+    public function testGetNamespace(): void
+    {
+        $config = new GRPCConfig([
+            'namespace' => 'foo',
+        ]);
+
+        $this->assertSame('foo', $config->getNamespace());
+    }
+
+    public function testGetNonExistsNamespace(): void
+    {
+        $config = new GRPCConfig();
+
+        $this->assertNull($config->getNamespace());
+    }
+
+    public function testGetServicesBasePath(): void
+    {
+        $config = new GRPCConfig([
+            'servicesBasePath' => 'foo',
+        ]);
+
+        $this->assertSame('foo', $config->getServicesBasePath());
+    }
+
+    public function testGetNonExistsServicesBasePath(): void
+    {
+        $config = new GRPCConfig();
+
+        $this->assertNull($config->getServicesBasePath());
+    }
 }

--- a/tests/src/GRPC/ProtocCommandBuilderTest.php
+++ b/tests/src/GRPC/ProtocCommandBuilderTest.php
@@ -18,7 +18,8 @@ class ProtocCommandBuilderTest extends TestCase
             $files = m::mock(FilesInterface::class),
             new GRPCConfig([
                 'servicesBasePath' => 'path4',
-            ])
+            ]),
+            'path3'
         );
 
         $files->shouldReceive('ensureDirectory')
@@ -27,11 +28,30 @@ class ProtocCommandBuilderTest extends TestCase
 
         $files->shouldReceive('normalizePath')->with($directory, true)->andReturn('path5');
 
-        $files->shouldReceive('getFiles')->with(\dirname('path1'))->andReturn();
+        $files->shouldReceive('getFiles')->with(\dirname('path1'))
+            ->andReturn([
+                'foo.proto',
+                'bar.proto',
+            ]);
 
         $this->assertSame(
-            "protoc --plugin=path3 --php_out='path2' --php-grpc_out='path2' -I='path4' -I='.'  2>&1",
-            $builder->build('path1', 'path2', 'path3')
+            "protoc --plugin=path3 --php_out='path2' --php-grpc_out='path2' -I='path4' -I='.' 'foo.proto' 'bar.proto' 2>&1",
+            $builder->build('path1', 'path2')
         );
+    }
+
+    public function testBuildWithNullServicesBasePath(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        $builder = new ProtocCommandBuilder(
+            m::mock(FilesInterface::class),
+            new GRPCConfig([
+                'servicesBasePath' => null,
+            ]),
+            'path3'
+        );
+
+        $builder->build('path1', 'path2');
     }
 }

--- a/tests/src/GRPC/ProtocCommandBuilderTest.php
+++ b/tests/src/GRPC/ProtocCommandBuilderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\GRPC;
+
+use Spiral\Files\FilesInterface;
+use Spiral\RoadRunnerBridge\Config\GRPCConfig;
+use Spiral\RoadRunnerBridge\GRPC\ProtocCommandBuilder;
+use Spiral\Tests\TestCase;
+use Mockery as m;
+
+class ProtocCommandBuilderTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $builder = new ProtocCommandBuilder(
+            $files = m::mock(FilesInterface::class),
+            new GRPCConfig([
+                'servicesBasePath' => 'path4'
+            ])
+        );
+
+        $files->shouldReceive('ensureDirectory')
+            ->with($directory = \sys_get_temp_dir() . '/' . \spl_object_hash($builder))
+            ->andReturn();
+
+        $files->shouldReceive('normalizePath')->with($directory, true)->andReturn('path5');
+
+        $files->shouldReceive('getFiles')->with(\dirname('path1'))->andReturn();
+
+        $this->assertSame(
+            "protoc --plugin=path3 --php_out='path2' --php-grpc_out='path2' -I='path4' -I='.'  2>&1",
+            $builder->build('path1', 'path2', 'path3')
+        );
+    }
+}

--- a/tests/src/GRPC/ProtocCommandBuilderTest.php
+++ b/tests/src/GRPC/ProtocCommandBuilderTest.php
@@ -10,7 +10,7 @@ use Spiral\RoadRunnerBridge\GRPC\ProtocCommandBuilder;
 use Spiral\Tests\TestCase;
 use Mockery as m;
 
-class ProtocCommandBuilderTest extends TestCase
+final class ProtocCommandBuilderTest extends TestCase
 {
     public function testBuild(): void
     {
@@ -30,14 +30,16 @@ class ProtocCommandBuilderTest extends TestCase
 
         $files->shouldReceive('getFiles')->with(\dirname('path1'))
             ->andReturn([
-                'foo.proto',
-                'bar.proto',
-                '.gitignore',
-                '.gitattributes'
+                 'message.proto.tmp',
+                 'service.proto.tmp',
+                 'message.proto',
+                 'service.proto',
+                 '.gitignore',
+                 '.gitattributes'
             ]);
 
         $this->assertSame(
-            "protoc --plugin=path3 --php_out='path2' --php-grpc_out='path2' -I='path4' -I='.' 'foo.proto' 'bar.proto' 2>&1",
+            "protoc --plugin=path3 --php_out='path2' --php-grpc_out='path2' -I='path4' -I='.' 'message.proto' 'service.proto' 2>&1",
             $builder->build('path1', 'path2')
         );
     }

--- a/tests/src/GRPC/ProtocCommandBuilderTest.php
+++ b/tests/src/GRPC/ProtocCommandBuilderTest.php
@@ -32,6 +32,8 @@ class ProtocCommandBuilderTest extends TestCase
             ->andReturn([
                 'foo.proto',
                 'bar.proto',
+                '.gitignore',
+                '.gitattributes'
             ]);
 
         $this->assertSame(

--- a/tests/src/GRPC/ProtocCommandBuilderTest.php
+++ b/tests/src/GRPC/ProtocCommandBuilderTest.php
@@ -17,7 +17,7 @@ class ProtocCommandBuilderTest extends TestCase
         $builder = new ProtocCommandBuilder(
             $files = m::mock(FilesInterface::class),
             new GRPCConfig([
-                'servicesBasePath' => 'path4'
+                'servicesBasePath' => 'path4',
             ])
         );
 


### PR DESCRIPTION
Add new parameters for GRPC сonfig:

By default `path` and `namespace` options are `auto` in `grpc:generate` command. Defined values from config will be used in `auto` mode, by default.

```php
return [
    /**
     * Path, where generated DTO files put.
     * Default: null
     */
    'generatedPath' => directory('root') . '/generated',

    /**
     * Base namespace for generated proto files.
     * Default: null
     */
    'namespace' => '\GRPC',

    /**
     * Root path for all proto files in which imports will be searched.
     * Default: null
     */
    'servicesBasePath' => directory('root') . '/proto',
];
```