### PR TITLE
Add proto file repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,40 +981,24 @@ Put proto file into `app/config/grpc.php`
 ],
 ```
 
-#### Proto files repository
+By default, generator will look for proto files using `Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository` in local folder.
 
-By default, GRPC looks for proto file in a directory. You have the ability to use repository for looking proto files.
+You can extend a behavior and change the place where to look for list of proto files, for example, create a repository like RRConfigProtoFilesRepository, or BufProtoFilesRepository
 
-The first thing you need to do is create a repository that implements `ProtoFilesRepositoryInterface`:
+There is complete example of how to use proto files repositories:
 ```php
 <?php
 
 declare(strict_types=1);
 
-namespace App\GRPC\ProtoRepository;
-
-class SomeRepository implements ProtoFilesRepositoryInterface
-{
-    public function getProtos(): iterable
-    {
-        // ...
-    }
-}
-```
-
-Then you need to bind repository in bootloader:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Bootloader\SomeBootloader;
+namespace App\Bootloader;
 
 use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeRepository;
-use App\GRPC\ProtoRepository\SomeRepository;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
+use App\GRPC\ProtoRepository\RRConfigProtoFilesRepository;
+use App\GRPC\ProtoRepository\BufProtoFilesRepository;
 
-final class SomeBootloader extends Bootloader
+final class AppBootloaderextends Bootloader
 {
     protected const SINGLETONS = [
         ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository'],
@@ -1022,12 +1006,11 @@ final class SomeBootloader extends Bootloader
 
     private function initProtoFilesRepository(): ProtoFilesRepositoryInterface
     {
-        return new SomeRepository();
-        // or this for multiple repositories
         return new CompositeRepository(
-            new SomeRepository(),
-            new YamlRepository(),
-            new BufRepository(),
+            new RRConfigProtoFilesRepository($pathToRRConfig),
+            new BufRepository([
+                  'https://buf.build/roadrunner-server/api/file/main:proto/shared/status.proto'
+            ]),
         );
     }
 }

--- a/README.md
+++ b/README.md
@@ -1003,6 +1003,7 @@ class SomeRepository implements ProtoFilesRepositoryInterface
 ```
 
 Then you need to bind repository in bootloader:
+
 ```php
 <?php
 
@@ -1010,7 +1011,7 @@ declare(strict_types=1);
 
 namespace App\Bootloader\SomeBootloader;
 
-use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeProtoFilesRepository;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeRepository;
 use App\GRPC\ProtoRepository\SomeRepository;
 
 final class SomeBootloader extends Bootloader
@@ -1023,7 +1024,7 @@ final class SomeBootloader extends Bootloader
     {
         return new SomeRepository();
         // or this for multiple repositories
-        return new CompositeProtoFilesRepository(
+        return new CompositeRepository(
             new SomeRepository(),
             new YamlRepository(),
             new BufRepository(),

--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,7 @@ Then you need to bind repository in bootloader:
 
 declare(strict_types=1);
 
-namespace Spiral\RoadRunnerBridge\Bootloader;
+namespace App\Bootloader\SomeBootloader;
 
 use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeProtoFilesRepository;
 use App\GRPC\ProtoRepository\SomeRepository;

--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,6 @@ final class SomeBootloader extends Bootloader
         );
     }
 }
-
 ```
 
 Run console command:

--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ Put proto file into `app/config/grpc.php`
 
 By default, generator will look for proto files using `Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository` in local folder.
 
-You can extend a behavior and change the place where to look for list of proto files, for example, create a repository like RRConfigProtoFilesRepository, or BufProtoFilesRepository
+You can extend a behavior and change the place where to look for list of proto files, for example, create a repository like `RRConfigProtoFilesRepository`, or `BufProtoFilesRepository`
 
 There is complete example of how to use proto files repositories:
 ```php

--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ Put proto file into `app/config/grpc.php`
 
 #### Proto files repository
 
-You have the ability to use repository for looking proto files.
+By default, GRPC looks for proto file in a directory. You have the ability to use repository for looking proto files.
 
 The first thing you need to do is create a repository that implements `ProtoFilesRepositoryInterface`:
 ```php

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ use Spiral\Cache\Storage\FileStorage;
 return [
 
     'default' => 'array',
-    
+
     /**
      *  Aliases for storages, if you want to use domain specific storages
      */
@@ -104,7 +104,7 @@ return [
             // Alias for ArrayStorage type
             'type' => 'array',
         ],
-        
+
         'localMemory' => [
             'type' => ArrayStorage::class,
         ],
@@ -114,7 +114,7 @@ return [
             'type' => 'file',
             'path' => __DIR__.'/../../runtime/cache',
         ],
-        
+
     ],
 
     /**
@@ -143,8 +143,8 @@ class MyService {
 
     private CacheInterface $cache;
     private PostReposiory $posts;
-    
-    public function __construct(CacheInterface $cache, PostReposiory $posts) 
+
+    public function __construct(CacheInterface $cache, PostReposiory $posts)
     {
         $this->cache = $cache;
         $this->posts = $posts;
@@ -154,7 +154,7 @@ class MyService {
     {
         $posts = $this->posts->findAll();
         $this->cache->set('posts', $posts);
-        
+
         // ...
     }
 }
@@ -174,8 +174,8 @@ class MyService {
 
     private CacheStorageProviderInterface $cacheManager;
     private PostReposiory $posts;
-    
-    public function __construct(CacheStorageProviderInterface $cacheManager, PostReposiory $posts) 
+
+    public function __construct(CacheStorageProviderInterface $cacheManager, PostReposiory $posts)
     {
         $this->cacheManager = $cacheManager;
         $this->posts = $posts;
@@ -185,10 +185,10 @@ class MyService {
     {
         /** @var \Psr\SimpleCache\CacheInterface $cache */
         $cache = $this->cacheManager->storage('inMemory');
-        
+
         $posts = $this->posts->findAll();
         $this->cache->set('posts', $posts);
-        
+
         // ...
     }
 }
@@ -218,8 +218,8 @@ class MyService {
 
     private CacheStorageProviderInterface $cacheManager;
     private PostReposiory $posts;
-    
-    public function __construct(CacheStorageProviderInterface $cacheManager, UserRepository $posts) 
+
+    public function __construct(CacheStorageProviderInterface $cacheManager, UserRepository $posts)
     {
         $this->cacheManager = $cacheManager;
         $this->posts = $posts;
@@ -229,7 +229,7 @@ class MyService {
     {
         /** @var \Psr\SimpleCache\CacheInterface $cache */
         $cache = $this->cacheManager->storage('user-data');
-        
+
         // ...
     }
 }
@@ -245,8 +245,8 @@ There are two ways to add cache storages:
 final class DatabaseStorage implements \Psr\SimpleCache\CacheInterface
 {
     private string $table;
-    
-    public function __construct(string $table) 
+
+    public function __construct(string $table)
     {
         $this->table = $table;
     }
@@ -314,7 +314,7 @@ return [
         // 'mail-queue' => 'roadrunner',
         // 'rating-queue' => 'sync',
     ],
-    
+
     /**
      * Queue connections
      * Drivers: "sync", "roadrunner"
@@ -333,32 +333,32 @@ return [
                     // Run consumer for this pipeline on startup (by default)
                     // You can pause consumer for this pipeline via console command
                     // php app.php queue:pause local
-                    'consume' => true 
+                    'consume' => true
                 ],
                 // 'amqp' => [
                 //     'connector' => new AMQPCreateInfo('bus', ...),
                 //     // Don't consume jobs for this pipeline on start
                 //     // You can run consumer for this pipeline via console command
                 //     // php app.php queue:resume local
-                //     'consume' => false 
+                //     'consume' => false
                 // ],
-                // 
+                //
                 // 'beanstalk' => [
                 //     'connector' => new BeanstalkCreateInfo('bus', ...),
                 // ],
-                // 
+                //
                 // 'sqs' => [
                 //     'connector' => new SQSCreateInfo('amazon', ...),
                 // ],
             ]
         ],
     ],
-    
+
     'driverAliases' => [
         'sync' => \Spiral\Queue\Driver\SyncDriver::class,
         'roadrunner' => \Spiral\RoadRunnerBridge\Queue\Queue::class,
     ],
-    
+
     'registry' => [
         'handlers' => [],
         'serializers' => [
@@ -403,12 +403,12 @@ class MyService {
 
     private ContainerInterface $container;
     private  QueueInterface $queue;
-    
+
     /**
      * @param QueueInterface $queue - Default queue will be injected
      * @param ContainerInterface $container
      */
-    public function __construct(QueueInterface $queue, ContainerInterface $container) 
+    public function __construct(QueueInterface $queue, ContainerInterface $container)
     {
         $this->container = $container;
         $this->queue = $queue;
@@ -417,13 +417,13 @@ class MyService {
     public function handle()
     {
         $queue = $this->queue;
-        
-        // OR gets queue from manager 
+
+        // OR gets queue from manager
 
         /** @var QueueManager $queueManager */
         $queueManager = $this->container->get(QueueConnectionProviderInterface::class);
         $queue = $queueManager->getConnection('sync');
-        
+
         $queue->push(PingHandler::class, ['url' => 'https://google.com']);
     }
 }
@@ -444,7 +444,7 @@ $queue->push('ping', ['url' => 'https://google.com']);
 
 #### Job serializer
 
-You can configure a specific serializer for a particular job. Add a job as a key with the desired serializer as a value 
+You can configure a specific serializer for a particular job. Add a job as a key with the desired serializer as a value
 in the `app/config/queue.php` configuration file:
 
 ```php
@@ -462,8 +462,8 @@ return [
 ];
 ```
 
-The serializer can be a string key from the `Spiral\Serializer\SerializerRegistry`. The fully qualified name of the serializer class, 
-serializer instance, `Spiral\Core\Container\Autowire` instance. 
+The serializer can be a string key from the `Spiral\Serializer\SerializerRegistry`. The fully qualified name of the serializer class,
+serializer instance, `Spiral\Core\Container\Autowire` instance.
 The serializer class must implement the `Spiral\Serializer\SerializerInterface`.
 
 #### Job DTO's
@@ -478,12 +478,12 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class Ping
 {
     private string $url;
-    
-    public function __construct(string $url) 
+
+    public function __construct(string $url)
     {
         $this->url = $url;
     }
-    
+
     public function __invoke(HttpClientInterface $client): void
     {
         $status = $client->request('GET', $this->url)->getStatusCode() === 200;
@@ -498,8 +498,8 @@ use Spiral\Queue\QueueInterface;
 class MyService {
 
     private QueueInterface $queue;
-    
-    public function __construct(QueueInterface $queue) 
+
+    public function __construct(QueueInterface $queue)
     {
         $this->queue = $queue;
     }
@@ -532,8 +532,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class MyService {
 
     private QueueInterface $queue;
-    
-    public function __construct(QueueConnectionProviderInterface $manager) 
+
+    public function __construct(QueueConnectionProviderInterface $manager)
     {
         $this->queue = $manager->getConnection('user-data');
     }
@@ -573,7 +573,7 @@ class DatabaseFailedJobsHandler implements FailedJobHandlerInterface
 {
     private DatabaseInterface $database;
     private SerializerInterface $serializer;
-    
+
     public function __construct(DatabaseInterface $database, SerializerInterface $serializer)
     {
         $this->database = $database;
@@ -620,7 +620,7 @@ protected const LOAD = [
     RoadRunnerBridge\QueueBootloader::class,
     App\Bootloader\QueueFailedJobsBootloader::class,
     RoadRunnerBridge\CommandBootloader::class,
-    
+
     // ...
 ];
 ```
@@ -641,7 +641,7 @@ protected const LOAD = [
 'memory' => [
     'driver' => 'roadrunner',
     'connector' => new MemoryCreateInfo('local'),
-    'consume' => true // Consume jobs 
+    'consume' => true // Consume jobs
 ],
 ```
 
@@ -665,7 +665,7 @@ use Spiral\RoadRunnerBridge\Bootloader as RoadRunnerBridge;
 
 protected const LOAD = [
     // ...
-    RoadRunnerBridge\TcpBootloader::class, 
+    RoadRunnerBridge\TcpBootloader::class,
     // ...
 ];
 ```
@@ -714,17 +714,17 @@ return [
 
     /**
      * Interceptors, this section is optional.
-     * @see https://spiral.dev/docs/cookbook-domain-core/2.8/en#core-interceptors  
+     * @see https://spiral.dev/docs/cookbook-domain-core/2.8/en#core-interceptors
      */
     'interceptors' => [
         // several interceptors
         'smtp' => [
-            SomeInterceptor::class, 
+            SomeInterceptor::class,
             OtherInterceptor::class
         ],
-        'monolog' => SomeInterceptor::class // one interceptor 
+        'monolog' => SomeInterceptor::class // one interceptor
     ],
-    
+
     'debug' => env('TCP_DEBUG', false)
 ];
 ```
@@ -756,7 +756,7 @@ class TestService implements ServiceInterface
     public function handle(Request $request): ResponseInterface
     {
         // some logic
-    
+
         return new RespondMessage('some message', true);
     }
 }
@@ -846,12 +846,12 @@ broadcast:
 ```php
 use Spiral\Broadcasting\BroadcastInterface;
 
-final class SendVerificationLink 
+final class SendVerificationLink
 {
     private BroadcastInterface $broadcast;
     private UserReposiory $users;
     private VerificationLinkGenerator $linkGenerator;
-    
+
     public function __construct(
         BroadcastInterface $broadcast,
         UserReposiory $users,
@@ -865,11 +865,11 @@ final class SendVerificationLink
     public function handle(int $userId): void
     {
         $user = $this->users->findByPK($userId);
-        
+
         // ...
-        
+
         $this->broadcast->publish(
-            'user.{$user->id}', 
+            'user.{$user->id}',
             \sprintf('Your verification link is: %s', $this->linkGenerator->getLink($user))
         );
     }
@@ -881,12 +881,12 @@ final class SendVerificationLink
 ```php
 use Spiral\Broadcasting\BroadcastManagerInterface;
 
-final class SendVerificationLink 
+final class SendVerificationLink
 {
     private BroadcastManagerInterface $broadcastManager;
     private UserReposiory $users;
     private VerificationLinkGenerator $linkGenerator;
-    
+
     public function __construct(
         BroadcastManagerInterface $broadcastManager,
         UserReposiory $users,
@@ -900,7 +900,7 @@ final class SendVerificationLink
     public function handle(int $userId): void
     {
         $broadcast = $this->broadcastManager->connection('log');
-        
+
         // ...
     }
 }
@@ -928,7 +928,7 @@ declare(strict_types=1);
 return [
     /**
      * Path to protoc-gen-php-grpc library.
-     * Default: null 
+     * Default: null
      */
     'binaryPath' => null,
     // 'binaryPath' => __DIR__.'/../../protoc-gen-php-grpc',
@@ -979,6 +979,58 @@ Put proto file into `app/config/grpc.php`
 'services' => [
     __DIR__.'/../../proto/echo.proto',
 ],
+```
+
+#### Proto files repository
+
+You have the ability to use repository for looking proto files.
+
+The first thing you need to do is create a repository that implements `ProtoFilesRepositoryInterface`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\GRPC\ProtoRepository;
+
+class SomeRepository implements ProtoFilesRepositoryInterface
+{
+    public function getProtos(): iterable
+    {
+        // ...
+    }
+}
+```
+
+Then you need to bind repository in bootloader:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\Bootloader;
+
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeProtoFilesRepository;
+use App\GRPC\ProtoRepository\SomeRepository;
+
+final class SomeBootloader extends Bootloader
+{
+    protected const SINGLETONS = [
+        ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository'],
+    ];
+
+    private function initProtoFilesRepository(): ProtoFilesRepositoryInterface
+    {
+        return new SomeRepository();
+        // or this for multiple repositories
+        return new CompositeProtoFilesRepository(
+            new SomeRepository(),
+            new YamlRepository(),
+            new BufRepository(),
+        );
+    }
+}
+
 ```
 
 Run console command:
@@ -1042,7 +1094,7 @@ use Spiral\RoadRunnerBridge\Logger\Handler;
 
 return [
    //...
-   
+
    'handlers' => [
        'roadrunner' => [
            Handler::class,
@@ -1066,7 +1118,7 @@ use Spiral\RoadRunnerBridge\Logger\Handler;
 
 final class SomeBootloader extends Bootloader
 {
-    public function init(MonologBootloader $monolog, Handler $handler): void 
+    public function init(MonologBootloader $monolog, Handler $handler): void
     {
         $monolog->addHandler($handler);
     }
@@ -1199,7 +1251,7 @@ class AppBootloader extends Bootloader
 To populate metric from application use `Spiral\RoadRunner\Metrics\MetricsInterface`:
 
 ```php
-use Spiral\RoadRunner\Metrics\MetricsInterface; 
+use Spiral\RoadRunner\Metrics\MetricsInterface;
 
 // ...
 
@@ -1246,7 +1298,7 @@ class MetricsBootloader extends Bootloader
 You should specify values for your labels while pushing the metric:
 
 ```php
-use Spiral\RoadRunner\MetricsInterface; 
+use Spiral\RoadRunner\MetricsInterface;
 
 // ...
 

--- a/src/Bootloader/GRPCBootloader.php
+++ b/src/Bootloader/GRPCBootloader.php
@@ -35,7 +35,7 @@ final class GRPCBootloader extends Bootloader
         Server::class => Server::class,
         InvokerInterface::class => [self::class, 'initInvoker'],
         LocatorInterface::class => ServiceLocator::class,
-        ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository']
+        ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository'],
     ];
 
     public function __construct(

--- a/src/Bootloader/GRPCBootloader.php
+++ b/src/Bootloader/GRPCBootloader.php
@@ -13,15 +13,17 @@ use Spiral\Core\Container\Autowire;
 use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\FactoryInterface;
 use Spiral\Core\InterceptableCore;
+use Spiral\RoadRunner\GRPC\Invoker as BaseInvoker;
 use Spiral\RoadRunner\GRPC\InvokerInterface;
 use Spiral\RoadRunner\GRPC\Server;
 use Spiral\RoadRunnerBridge\Config\GRPCConfig;
 use Spiral\RoadRunnerBridge\GRPC\Dispatcher;
-use Spiral\RoadRunnerBridge\GRPC\Interceptor\InvokerCore;
 use Spiral\RoadRunnerBridge\GRPC\Interceptor\Invoker;
+use Spiral\RoadRunnerBridge\GRPC\Interceptor\InvokerCore;
 use Spiral\RoadRunnerBridge\GRPC\LocatorInterface;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
 use Spiral\RoadRunnerBridge\GRPC\ServiceLocator;
-use Spiral\RoadRunner\GRPC\Invoker as BaseInvoker;
 
 final class GRPCBootloader extends Bootloader
 {
@@ -33,6 +35,7 @@ final class GRPCBootloader extends Bootloader
         Server::class => Server::class,
         InvokerInterface::class => [self::class, 'initInvoker'],
         LocatorInterface::class => ServiceLocator::class,
+        ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository']
     ];
 
     public function __construct(
@@ -103,5 +106,10 @@ final class GRPCBootloader extends Bootloader
         }
 
         return new Invoker($core);
+    }
+
+    private function initProtoFilesRepository(GRPCConfig $config): ProtoFilesRepositoryInterface
+    {
+        return new FileRepository($config->getServices());
     }
 }

--- a/src/Console/Command/GRPC/GenerateCommand.php
+++ b/src/Console/Command/GRPC/GenerateCommand.php
@@ -12,6 +12,7 @@ use Spiral\Files\FilesInterface;
 use Spiral\RoadRunnerBridge\Config\GRPCConfig;
 use Spiral\RoadRunnerBridge\GRPC\Exception\CompileException;
 use Spiral\RoadRunnerBridge\GRPC\ProtoCompiler;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
 
 final class GenerateCommand extends Command
 {
@@ -24,7 +25,8 @@ final class GenerateCommand extends Command
         KernelInterface $kernel,
         FilesInterface $files,
         DirectoriesInterface $dirs,
-        GRPCConfig $config
+        GRPCConfig $config,
+        ProtoFilesRepositoryInterface $repository
     ): int {
         $binaryPath = $config->getBinaryPath();
 
@@ -41,7 +43,7 @@ final class GenerateCommand extends Command
             $binaryPath
         );
 
-        foreach ($config->getServices() as $protoFile) {
+        foreach ($repository->getProtos() as $protoFile) {
             if (!\file_exists($protoFile)) {
                 $this->sprintf('<error>Proto file `%s` not found.</error>', $protoFile);
                 continue;

--- a/src/GRPC/ProtoRepository/CompositeProtoFilesRepository.php
+++ b/src/GRPC/ProtoRepository/CompositeProtoFilesRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
 
-class CompositeProtoFilesRepository implements ProtoFilesRepositoryInterface
+final class CompositeProtoFilesRepository implements ProtoFilesRepositoryInterface
 {
     private readonly array $repositories;
 

--- a/src/GRPC/ProtoRepository/CompositeProtoFilesRepository.php
+++ b/src/GRPC/ProtoRepository/CompositeProtoFilesRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
+
+class CompositeProtoFilesRepository implements ProtoFilesRepositoryInterface
+{
+    private readonly array $repositories;
+
+    public function __construct(ProtoFilesRepositoryInterface ...$repositories)
+    {
+        $this->repositories = $repositories;
+    }
+
+    public function getProtos(): iterable
+    {
+        foreach ($this->repositories as $repository) {
+            yield from $repository->getProtos();
+        }
+    }
+}

--- a/src/GRPC/ProtoRepository/CompositeRepository.php
+++ b/src/GRPC/ProtoRepository/CompositeRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
 
-final class CompositeProtoFilesRepository implements ProtoFilesRepositoryInterface
+final class CompositeRepository implements ProtoFilesRepositoryInterface
 {
     private readonly array $repositories;
 

--- a/src/GRPC/ProtoRepository/FileRepository.php
+++ b/src/GRPC/ProtoRepository/FileRepository.php
@@ -6,8 +6,9 @@ namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
 
 final class FileRepository implements ProtoFilesRepositoryInterface
 {
-    public function __construct(private readonly array $protoFiles)
-    {
+    public function __construct(
+        private readonly array $protoFiles
+    ) {
     }
 
     public function getProtos(): iterable

--- a/src/GRPC/ProtoRepository/FileRepository.php
+++ b/src/GRPC/ProtoRepository/FileRepository.php
@@ -10,11 +10,8 @@ class FileRepository implements ProtoFilesRepositoryInterface
     {
     }
 
-    /**
-     * @return array<non-empty-string>
-     */
     public function getProtos(): iterable
     {
-        return $this->protoFiles;
+        yield from $this->protoFiles;
     }
 }

--- a/src/GRPC/ProtoRepository/FileRepository.php
+++ b/src/GRPC/ProtoRepository/FileRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
+
+class FileRepository implements ProtoFilesRepositoryInterface
+{
+    public function __construct(private readonly array $protoFiles)
+    {
+    }
+
+    /**
+     * @return array<non-empty-string>
+     */
+    public function getProtos(): iterable
+    {
+        return $this->protoFiles;
+    }
+}

--- a/src/GRPC/ProtoRepository/FileRepository.php
+++ b/src/GRPC/ProtoRepository/FileRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
 
-class FileRepository implements ProtoFilesRepositoryInterface
+final class FileRepository implements ProtoFilesRepositoryInterface
 {
     public function __construct(private readonly array $protoFiles)
     {

--- a/src/GRPC/ProtoRepository/ProtoFilesRepositoryInterface.php
+++ b/src/GRPC/ProtoRepository/ProtoFilesRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
+
+interface ProtoFilesRepositoryInterface
+{
+    /**
+     * @return iterable<non-empty-string>
+     */
+    public function getProtos(): iterable;
+}

--- a/src/GRPC/ProtoRepository/ProtoFilesRepositoryInterface.php
+++ b/src/GRPC/ProtoRepository/ProtoFilesRepositoryInterface.php
@@ -7,6 +7,8 @@ namespace Spiral\RoadRunnerBridge\GRPC\ProtoRepository;
 interface ProtoFilesRepositoryInterface
 {
     /**
+     * Get proto files paths
+     *
      * @return iterable<non-empty-string>
      */
     public function getProtos(): iterable;

--- a/tests/src/Bootloader/GRPCBootloaderTest.php
+++ b/tests/src/Bootloader/GRPCBootloaderTest.php
@@ -16,6 +16,8 @@ use Spiral\RoadRunnerBridge\Bootloader\GRPCBootloader;
 use Spiral\RoadRunnerBridge\Config\GRPCConfig;
 use Spiral\RoadRunnerBridge\GRPC\Dispatcher;
 use Spiral\RoadRunnerBridge\GRPC\LocatorInterface;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
 use Spiral\RoadRunnerBridge\GRPC\ServiceLocator;
 use Spiral\Tests\TestCase;
 use Mockery as m;
@@ -43,6 +45,14 @@ final class GRPCBootloaderTest extends TestCase
         $this->assertContainerBoundAsSingleton(
             LocatorInterface::class,
             ServiceLocator::class
+        );
+    }
+
+    public function testGetsProtoFilesRepository()
+    {
+        $this->assertContainerBoundAsSingleton(
+            ProtoFilesRepositoryInterface::class,
+            FileRepository::class
         );
     }
 

--- a/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
+++ b/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
@@ -21,6 +21,6 @@ class CompositeProtoFilesRepositoryTest extends TestCase
 
         $fooRepository->shouldReceive('getProtos')->withNoArgs()->andReturn(['path1', 'path2']);
 
-        $this->assertSame(['path1', 'path2', 'path3', 'path4'], iterator_to_array($repository->getProtos(), false));
+        $this->assertSame(['path1', 'path2', 'path3', 'path4'], \iterator_to_array($repository->getProtos(), false));
     }
 }

--- a/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
+++ b/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\GRPC\ProtoRepository;
 
 use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeProtoFilesRepository;
 use Mockery as m;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository;
 use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
 use Spiral\Tests\TestCase;
 
@@ -15,12 +16,11 @@ class CompositeProtoFilesRepositoryTest extends TestCase
     {
         $repository = new CompositeProtoFilesRepository(
             $fooRepository = m::mock(ProtoFilesRepositoryInterface::class),
-            $barRepository = m::mock(ProtoFilesRepositoryInterface::class)
+            new FileRepository(['path3', 'path4']),
         );
 
-        $fooRepository->shouldReceive('getProtos')->withNoArgs()->andReturn(['test1', 'test2']);
-        $barRepository->shouldReceive('getProtos')->withNoArgs()->andReturn(['test3', 'test4']);
+        $fooRepository->shouldReceive('getProtos')->withNoArgs()->andReturn(['path1', 'path2']);
 
-        $this->assertSame(['test1', 'test2', 'test3', 'test4'], iterator_to_array($repository->getProtos(), false));
+        $this->assertSame(['path1', 'path2', 'path3', 'path4'], iterator_to_array($repository->getProtos(), false));
     }
 }

--- a/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
+++ b/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\GRPC\ProtoRepository;
 
-use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeProtoFilesRepository;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeRepository;
 use Mockery as m;
 use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository;
 use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
@@ -14,7 +14,7 @@ class CompositeProtoFilesRepositoryTest extends TestCase
 {
     public function testGetProtos(): void
     {
-        $repository = new CompositeProtoFilesRepository(
+        $repository = new CompositeRepository(
             $fooRepository = m::mock(ProtoFilesRepositoryInterface::class),
             new FileRepository(['path3', 'path4']),
         );

--- a/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
+++ b/tests/src/GRPC/ProtoRepository/CompositeProtoFilesRepositoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\GRPC\ProtoRepository;
+
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeProtoFilesRepository;
+use Mockery as m;
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
+use Spiral\Tests\TestCase;
+
+class CompositeProtoFilesRepositoryTest extends TestCase
+{
+    public function testGetProtos(): void
+    {
+        $repository = new CompositeProtoFilesRepository(
+            $fooRepository = m::mock(ProtoFilesRepositoryInterface::class),
+            $barRepository = m::mock(ProtoFilesRepositoryInterface::class)
+        );
+
+        $fooRepository->shouldReceive('getProtos')->withNoArgs()->andReturn(['test1', 'test2']);
+        $barRepository->shouldReceive('getProtos')->withNoArgs()->andReturn(['test3', 'test4']);
+
+        $this->assertSame(['test1', 'test2', 'test3', 'test4'], iterator_to_array($repository->getProtos(), false));
+    }
+}

--- a/tests/src/GRPC/ProtoRepository/FileRepositoryTest.php
+++ b/tests/src/GRPC/ProtoRepository/FileRepositoryTest.php
@@ -13,6 +13,6 @@ class FileRepositoryTest extends TestCase
     {
         $repository = new FileRepository($arr = ['foo', 'bar']);
 
-        $this->assertSame($arr, iterator_to_array($repository->getProtos(), false));
+        $this->assertSame($arr, \iterator_to_array($repository->getProtos(), false));
     }
 }

--- a/tests/src/GRPC/ProtoRepository/FileRepositoryTest.php
+++ b/tests/src/GRPC/ProtoRepository/FileRepositoryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\GRPC\ProtoRepository;
+
+use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository;
+use Spiral\Tests\TestCase;
+
+class FileRepositoryTest extends TestCase
+{
+    public function testGetProtos(): void
+    {
+        $repository = new FileRepository($arr = ['foo', 'bar']);
+
+        $this->assertSame($arr, $repository->getProtos());
+    }
+}

--- a/tests/src/GRPC/ProtoRepository/FileRepositoryTest.php
+++ b/tests/src/GRPC/ProtoRepository/FileRepositoryTest.php
@@ -13,6 +13,6 @@ class FileRepositoryTest extends TestCase
     {
         $repository = new FileRepository($arr = ['foo', 'bar']);
 
-        $this->assertSame($arr, $repository->getProtos());
+        $this->assertSame($arr, iterator_to_array($repository->getProtos(), false));
     }
 }


### PR DESCRIPTION
After the PR developers will have an ability to use repositories for looking for proto files.

By default, generator will look for proto files using `Spiral\RoadRunnerBridge\GRPC\ProtoRepository\FileRepository` in local folder.

You can extend a behavior and change the place where to look for list of proto files, for example, create a repository like `RRConfigProtoFilesRepository`, or `BufProtoFilesRepository`

There is complete example of how to use proto files repositories:
```php
<?php

declare(strict_types=1);

namespace App\Bootloader;

use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\CompositeRepository;
use Spiral\RoadRunnerBridge\GRPC\ProtoRepository\ProtoFilesRepositoryInterface;
use App\GRPC\ProtoRepository\RRConfigProtoFilesRepository;
use App\GRPC\ProtoRepository\BufProtoFilesRepository;

final class AppBootloaderextends Bootloader
{
    protected const SINGLETONS = [
        ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository'],
    ];

    private function initProtoFilesRepository(): ProtoFilesRepositoryInterface
    {
        return new CompositeRepository(
            new RRConfigProtoFilesRepository($pathToRRConfig),
            new BufRepository([
                  'https://buf.build/roadrunner-server/api/file/main:proto/shared/status.proto'   
            ]),
        );
    }
}
```