### PR TITLE
Removing assert in the ServiceClientCore

### DIFF
--- a/src/GRPC/Interceptor/ServiceClientCore.php
+++ b/src/GRPC/Interceptor/ServiceClientCore.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunnerBridge\GRPC\Interceptor;
 
-use Google\Protobuf\Internal\Message;
 use Spiral\Core\CoreInterface;
 use Spiral\RoadRunner\GRPC\ContextInterface;
 
@@ -12,13 +11,11 @@ final class ServiceClientCore extends \Grpc\BaseStub implements CoreInterface
 {
     public function callAction(string $controller, string $action, array $parameters = []): mixed
     {
-        \assert($parameters['responseClass'] instanceof Message);
         \assert($parameters['ctx'] instanceof ContextInterface);
 
         /** @var ContextInterface $ctx */
         $ctx = $parameters['ctx'];
 
-        /** @psalm-suppress InvalidArgument */
         return $this->_simpleRequest(
             $action,
             $parameters['in'],


### PR DESCRIPTION
This is a bug. `responseClass` is a class-string.