### PR TITLE
Fixes ServiceBootloader `initServices` method generation

### DIFF
--- a/src/GRPC/Generator/BootloaderGenerator.php
+++ b/src/GRPC/Generator/BootloaderGenerator.php
@@ -97,7 +97,8 @@ EOL,
     private function updateInitServicesMethod(FileDeclaration $file, array $files): void
     {
         $method = $file->getClass(self::BOOTLOADER_NAME)->getMethod('initServices');
-
+        $method->setBody('');
+        
         foreach ($files as $service) {
             if (!\str_ends_with($service, 'Interface.php')) {
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌ 

Исправлена проблема, что при запуске `grpc:generate` функция initServices в ServiceBootloader не обнулялась, а продолжалась дозаписываться. Данный PR решает данную проблему.