### PR TITLE
Remove abandoned package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "spiral/scaffolder": "^3.7"
     },
     "require-dev": {
-        "spiral/testing": "^2.3",
+        "spiral/testing": "^2.6.1",
         "phpunit/phpunit": "^10.1",
         "vimeo/psalm": "^5.0",
         "spiral/nyholm-bridge": "^1.2"

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/simple-cache": "3",
-        "php-http/message-factory": "^1.0",
+        "psr/simple-cache": "^3.0",
+        "psr/http-factory": "^1.0.2",
         "grpc/grpc": "^1.42",
         "roadrunner-php/centrifugo": "^2.0",
         "spiral/roadrunner-http": "^3.0",

--- a/src/GRPC/Generator/BootloaderGenerator.php
+++ b/src/GRPC/Generator/BootloaderGenerator.php
@@ -98,7 +98,6 @@ EOL,
     {
         $method = $file->getClass(self::BOOTLOADER_NAME)->getMethod('initServices');
         $method->setBody('');
-        
         foreach ($files as $service) {
             if (!\str_ends_with($service, 'Interface.php')) {
                 continue;

--- a/tests/src/Console/Command/Queue/ListCommandTest.php
+++ b/tests/src/Console/Command/Queue/ListCommandTest.php
@@ -11,10 +11,10 @@ use Spiral\Tests\ConsoleTestCase;
 
 final class ListCommandTest extends ConsoleTestCase
 {
-    public function testGetsListOfAvailablePipelines()
+    public function testGetsListOfAvailablePipelines(): void
     {
         $jobs = \Mockery::mock(JobsInterface::class);
-        $this->getContainer()->bind(JobsInterface::class, $jobs);
+        $this->getContainer()->bindSingleton(JobsInterface::class, $jobs, true);
 
         $jobs->shouldReceive('getIterator')->andReturn(
             new \ArrayIterator([

--- a/tests/src/Console/Command/Queue/PauseCommandTest.php
+++ b/tests/src/Console/Command/Queue/PauseCommandTest.php
@@ -9,10 +9,10 @@ use Spiral\Tests\ConsoleTestCase;
 
 final class PauseCommandTest extends ConsoleTestCase
 {
-    public function testPausePipeline()
+    public function testPausePipeline(): void
     {
         $jobs = \Mockery::mock(JobsInterface::class);
-        $this->getContainer()->bind(JobsInterface::class, $jobs);
+        $this->getContainer()->bindSingleton(JobsInterface::class, $jobs, true);
 
         $jobs->shouldReceive('pause')->once()->with('foo');
 

--- a/tests/src/RoadRunnerModeTest.php
+++ b/tests/src/RoadRunnerModeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Spiral\Boot\Injector\EnumInjector;
 use Spiral\RoadRunner\Environment;
 use Spiral\RoadRunner\EnvironmentInterface;
 use Spiral\RoadRunnerBridge\RoadRunnerMode;
@@ -15,14 +16,15 @@ final class RoadRunnerModeTest extends TestCase
     {
         parent::setUp();
         $this->getContainer()->removeBinding(RoadRunnerMode::class);
+        $this->getContainer()->bindInjector(RoadRunnerMode::class, EnumInjector::class);
     }
 
     #[DataProvider('roadRunnerModes')]
     public function testDetectMode(string $mode, RoadRunnerMode $expected): void
     {
-        $this->getContainer()->bind(EnvironmentInterface::class, static fn () => new Environment([
+        $this->getContainer()->bindSingleton(EnvironmentInterface::class, static fn () => new Environment([
             'RR_MODE' => $mode,
-        ]));
+        ]), true);
 
         $this->assertSame($expected, $this->getContainer()->get(RoadRunnerMode::class));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | #87 

We already use the `psr/http-factory` package in our code. Here:
https://github.com/spiral/roadrunner-bridge/blob/3.x/src/Bootloader/HttpBootloader.php#L7

And here:
https://github.com/spiral/roadrunner-bridge/blob/3.x/src/Http/Dispatcher.php#L7

The code from the **php-http/message-factory** package was not used anywhere.

The psr/http-factory package was not added explicitly and was installed because other packages required it. Added it as a dependency.