### PR TITLE
RoadRunner Lock Plugin Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ protected const LOAD = [
     RoadRunnerBridge\TcpBootloader::class, // Optional, if it needs to work with TCP plugin
     RoadRunnerBridge\MetricsBootloader::class, // Optional, if it needs to work with metrics plugin
     RoadRunnerBridge\LoggerBootloader::class, // Optional, if it needs to work with app-logger plugin
+    RoadRunnerBridge\LockBootloader::class, // Optional, if it needs to work with lock plugin
     RoadRunnerBridge\ScaffolderBootloader::class, // Optional, to generate Centrifugo handlers and TCP services via Scaffolder
     RoadRunnerBridge\CommandBootloader::class,
     // ...

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,10 @@
             "url": "https://github.com/sponsors/roadrunner-server"
         }
     ],
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "psalm": "vendor/bin/psalm --no-cache --config=psalm.xml ./src"
+    },
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,11 @@
     "license": "MIT",
     "homepage": "https://spiral.dev",
     "support": {
-        "issues": "https://github.com/spiral/framework/issues",
-        "source": "https://github.com/spiral/roadrunner-bridge"
+        "issues": "https://github.com/spiral/roadrunner-bridge/issues",
+        "source": "https://github.com/spiral/roadrunner-bridge",
+        "docs": "https://spiral.dev/docs",
+        "forum": "https://forum.spiral.dev",
+        "chat": "https://discord.gg/V6EK4he"
     },
     "authors": [
         {
@@ -14,8 +17,16 @@
             "email": "wolfy-j@spiralscout.com"
         },
         {
-            "name": "Pavel Buchnev (butschster)",
+            "name": "Pavel Butchnev (butschster)",
             "email": "pavel.buchnev@spiralscout.com"
+        },
+        {
+            "name": "Aleksei Gagarin (roxblnfk)",
+            "email": "alexey.gagarin@spiralscout.com"
+        },
+        {
+            "name": "Maksim Smakouz (msmakouz)",
+            "email": "maksim.smakouz@spiralscout.com"
         }
     ],
     "require": {
@@ -23,7 +34,6 @@
         "psr/simple-cache": "^3.0",
         "psr/http-factory": "^1.0.2",
         "grpc/grpc": "^1.42",
-        "roadrunner-php/centrifugo": "^2.0",
         "spiral/roadrunner-http": "^3.0",
         "spiral/roadrunner-grpc": "^3.2",
         "spiral/roadrunner-jobs": "^4.0",
@@ -31,15 +41,20 @@
         "spiral/roadrunner-tcp": "^3.0",
         "spiral/roadrunner-metrics": "^3.0",
         "roadrunner-php/app-logger": "^1.0",
-        "spiral/framework": "^3.7",
+        "roadrunner-php/centrifugo": "^2.0",
+        "roadrunner-php/lock": "^1.0",
         "spiral/serializer": "^3.7",
         "spiral/scaffolder": "^3.7"
     },
     "require-dev": {
+        "spiral/framework": "^3.7",
         "spiral/testing": "^2.6.1",
         "phpunit/phpunit": "^10.1",
         "vimeo/psalm": "^5.0",
         "spiral/nyholm-bridge": "^1.2"
+    },
+    "suggest": {
+        "ext-protobuf": "For better performance, install the protobuf C extension."
     },
     "autoload": {
         "psr-4": {
@@ -54,6 +69,12 @@
             "Spiral\\Tests\\": "tests/src"
         }
     },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/roadrunner-server"
+        }
+    ],
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/src/Bootloader/CacheBootloader.php
+++ b/src/Bootloader/CacheBootloader.php
@@ -25,7 +25,7 @@ final class CacheBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
-            FactoryInterface::class => static fn(
+            FactoryInterface::class => static fn (
                 RPCInterface $rpc,
                 SerializerInterface $serializer,
             ): FactoryInterface => new Factory($rpc, $serializer),
@@ -39,13 +39,12 @@ final class CacheBootloader extends Bootloader
         return [
             StorageInterface::class =>
             /** @param non-empty-string $driver */
-            static fn(
+            static fn (
                 FactoryInterface $factory,
                 string $driver,
             ): StorageInterface => $factory->select($driver),
         ];
     }
-
 
     public function init(BaseCacheBootloader $cacheBootloader): void
     {

--- a/src/Bootloader/CentrifugoBootloader.php
+++ b/src/Bootloader/CentrifugoBootloader.php
@@ -25,17 +25,20 @@ use Spiral\RoadRunnerBridge\Config\CentrifugoConfig;
 
 final class CentrifugoBootloader extends Bootloader
 {
-    protected const SINGLETONS = [
-        RegistryInterface::class => [self::class, 'initServiceRegistry'],
-        Interceptor\RegistryInterface::class => [self::class, 'initInterceptorRegistry'],
-        CentrifugoWorkerInterface::class => CentrifugoWorker::class,
-        ErrorHandlerInterface::class => LogErrorHandler::class,
-        CentrifugoApiInterface::class => RPCCentrifugoApi::class,
-    ];
-
     public function __construct(
         private readonly ConfiguratorInterface $config,
     ) {
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            RegistryInterface::class => [self::class, 'initServiceRegistry'],
+            Interceptor\RegistryInterface::class => [self::class, 'initInterceptorRegistry'],
+            CentrifugoWorkerInterface::class => CentrifugoWorker::class,
+            ErrorHandlerInterface::class => LogErrorHandler::class,
+            CentrifugoApiInterface::class => RPCCentrifugoApi::class,
+        ];
     }
 
     private function initConfig(): void
@@ -49,17 +52,14 @@ final class CentrifugoBootloader extends Bootloader
         );
     }
 
-    public function init(
-        BroadcastingBootloader $broadcasting,
-    ): void {
+    public function init(BroadcastingBootloader $broadcasting): void
+    {
         $this->initConfig();
         $broadcasting->registerDriverAlias(Broadcast::class, 'centrifugo');
     }
 
-    public function boot(
-        AbstractKernel $kernel,
-        Dispatcher $dispatcher,
-    ): void {
+    public function boot(AbstractKernel $kernel, Dispatcher $dispatcher): void
+    {
         $kernel->addDispatcher($dispatcher);
     }
 

--- a/src/Bootloader/GRPCBootloader.php
+++ b/src/Bootloader/GRPCBootloader.php
@@ -33,21 +33,27 @@ use Spiral\RoadRunnerBridge\GRPC\ServiceLocator;
 
 final class GRPCBootloader extends Bootloader
 {
-    protected const DEPENDENCIES = [
-        RoadRunnerBootloader::class,
-    ];
-
-    protected const SINGLETONS = [
-        Server::class => Server::class,
-        InvokerInterface::class => [self::class, 'initInvoker'],
-        LocatorInterface::class => ServiceLocator::class,
-        ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository'],
-        GeneratorRegistryInterface::class => [self::class, 'initGeneratorRegistry'],
-    ];
-
     public function __construct(
-        private readonly ConfiguratorInterface $config
+        private readonly ConfiguratorInterface $config,
     ) {
+    }
+
+    public function defineDependencies(): array
+    {
+        return [
+            RoadRunnerBootloader::class,
+        ];
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            Server::class => Server::class,
+            InvokerInterface::class => [self::class, 'initInvoker'],
+            LocatorInterface::class => ServiceLocator::class,
+            ProtoFilesRepositoryInterface::class => [self::class, 'initProtoFilesRepository'],
+            GeneratorRegistryInterface::class => [self::class, 'initGeneratorRegistry'],
+        ];
     }
 
     public function init(): void
@@ -79,7 +85,7 @@ final class GRPCBootloader extends Bootloader
                     ConfigGenerator::class,
                     BootloaderGenerator::class,
                 ],
-            ]
+            ],
         );
     }
 
@@ -90,7 +96,7 @@ final class GRPCBootloader extends Bootloader
     {
         $this->config->modify(
             GRPCConfig::CONFIG,
-            new Append('interceptors', null, $interceptor)
+            new Append('interceptors', null, $interceptor),
         );
     }
 
@@ -106,10 +112,10 @@ final class GRPCBootloader extends Bootloader
         GRPCConfig $config,
         ContainerInterface $container,
         FactoryInterface $factory,
-        BaseInvoker $invoker
+        BaseInvoker $invoker,
     ): InvokerInterface {
         $core = new InterceptableCore(
-            new InvokerCore($invoker)
+            new InvokerCore($invoker),
         );
 
         foreach ($config->getInterceptors() as $interceptor) {
@@ -131,7 +137,7 @@ final class GRPCBootloader extends Bootloader
     private function initGeneratorRegistry(
         GRPCConfig $config,
         ContainerInterface $container,
-        FactoryInterface $factory
+        FactoryInterface $factory,
     ): GeneratorRegistryInterface {
         $registry = new GeneratorRegistry();
         foreach ($config->getGenerators() as $generator) {

--- a/src/Bootloader/HttpBootloader.php
+++ b/src/Bootloader/HttpBootloader.php
@@ -20,28 +20,31 @@ use Spiral\RoadRunnerBridge\Http\LogErrorHandler;
 
 final class HttpBootloader extends Bootloader
 {
-    protected const DEPENDENCIES = [
-        RoadRunnerBootloader::class,
-        BaseHttpBootloader::class,
-    ];
+    public function defineDependencies(): array
+    {
+        return [
+            RoadRunnerBootloader::class,
+            BaseHttpBootloader::class,
+        ];
+    }
 
-    protected const SINGLETONS = [
-        ErrorHandlerInterface::class => LogErrorHandler::class,
-        PSR7Worker::class => PSR7WorkerInterface::class,
-        PSR7WorkerInterface::class => [self::class, 'initPSR7Worker'],
-    ];
+    public function defineSingletons(): array
+    {
+        return [
+            ErrorHandlerInterface::class => LogErrorHandler::class,
+            PSR7Worker::class => PSR7WorkerInterface::class,
+
+            PSR7WorkerInterface::class => static fn(
+                WorkerInterface $worker,
+                ServerRequestFactoryInterface $requests,
+                StreamFactoryInterface $streams,
+                UploadedFileFactoryInterface $uploads,
+            ): PSR7WorkerInterface => new PSR7Worker($worker, $requests, $streams, $uploads),
+        ];
+    }
 
     public function boot(KernelInterface $kernel, FactoryInterface $factory): void
     {
         $kernel->addDispatcher($factory->make(Dispatcher::class));
-    }
-
-    private function initPSR7Worker(
-        WorkerInterface $worker,
-        ServerRequestFactoryInterface $requests,
-        StreamFactoryInterface $streams,
-        UploadedFileFactoryInterface $uploads,
-    ): PSR7WorkerInterface {
-        return new PSR7Worker($worker, $requests, $streams, $uploads);
     }
 }

--- a/src/Bootloader/HttpBootloader.php
+++ b/src/Bootloader/HttpBootloader.php
@@ -34,7 +34,7 @@ final class HttpBootloader extends Bootloader
             ErrorHandlerInterface::class => LogErrorHandler::class,
             PSR7Worker::class => PSR7WorkerInterface::class,
 
-            PSR7WorkerInterface::class => static fn(
+            PSR7WorkerInterface::class => static fn (
                 WorkerInterface $worker,
                 ServerRequestFactoryInterface $requests,
                 StreamFactoryInterface $streams,

--- a/src/Bootloader/LockBootloader.php
+++ b/src/Bootloader/LockBootloader.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerBridge\Bootloader;
+
+use RoadRunner\Lock\Lock;
+use RoadRunner\Lock\LockInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+
+final class LockBootloader extends Bootloader
+{
+    public function defineBindings(): array
+    {
+        return [
+            RoadRunnerBootloader::class,
+        ];
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            LockInterface::class => Lock::class,
+        ];
+    }
+}

--- a/src/Bootloader/LockBootloader.php
+++ b/src/Bootloader/LockBootloader.php
@@ -10,7 +10,7 @@ use Spiral\Boot\Bootloader\Bootloader;
 
 final class LockBootloader extends Bootloader
 {
-    public function defineBindings(): array
+    public function defineDependencies(): array
     {
         return [
             RoadRunnerBootloader::class,

--- a/src/Bootloader/LoggerBootloader.php
+++ b/src/Bootloader/LoggerBootloader.php
@@ -14,23 +14,34 @@ use Spiral\RoadRunnerBridge\RoadRunnerMode;
 
 final class LoggerBootloader extends Bootloader
 {
-    protected const DEPENDENCIES = [
-        RoadRunnerBootloader::class,
-    ];
+    public function defineDependencies(): array
+    {
+        return [
+            RoadRunnerBootloader::class,
+        ];
+    }
 
-    protected const SINGLETONS = [
-        Handler::class => [self::class, 'initHandler'],
-    ];
+    public function defineSingletons(): array
+    {
+        return [
+            Handler::class => static function (
+                Logger $logger,
+                RoadRunnerMode $mode,
+                EnvironmentInterface $env,
+            ): Handler {
+                $fallbackHandler = $mode === RoadRunnerMode::Unknown ? new ErrorLogHandler() : null;
+
+                return new Handler(
+                    logger: $logger,
+                    fallbackHandler: $fallbackHandler,
+                    formatter: $env->get('LOGGER_FORMAT', Handler::FORMAT),
+                );
+            },
+        ];
+    }
 
     public function init(MonologBootloader $bootloader, Handler $handler): void
     {
         $bootloader->addHandler('roadrunner', $handler);
-    }
-
-    private function initHandler(Logger $logger, RoadRunnerMode $mode, EnvironmentInterface $env): Handler
-    {
-        $fallbackHandler = $mode === RoadRunnerMode::Unknown ? new ErrorLogHandler() : null;
-
-        return new Handler($logger, $fallbackHandler, $env->get('LOGGER_FORMAT', Handler::FORMAT));
     }
 }

--- a/src/Bootloader/MetricsBootloader.php
+++ b/src/Bootloader/MetricsBootloader.php
@@ -21,7 +21,7 @@ final class MetricsBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
-            MetricsInterface::class => static fn(RPCInterface $rpc): MetricsInterface => new Metrics($rpc),
+            MetricsInterface::class => static fn (RPCInterface $rpc): MetricsInterface => new Metrics($rpc),
         ];
     }
 }

--- a/src/Bootloader/MetricsBootloader.php
+++ b/src/Bootloader/MetricsBootloader.php
@@ -11,16 +11,17 @@ use Spiral\RoadRunner\Metrics\MetricsInterface;
 
 final class MetricsBootloader extends Bootloader
 {
-    protected const DEPENDENCIES = [
-        RoadRunnerBootloader::class,
-    ];
-
-    protected const SINGLETONS = [
-        MetricsInterface::class => [self::class, 'initMetrics'],
-    ];
-
-    protected function initMetrics(RPCInterface $rpc): MetricsInterface
+    public function defineDependencies(): array
     {
-        return new Metrics($rpc);
+        return [
+            RoadRunnerBootloader::class,
+        ];
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            MetricsInterface::class => static fn(RPCInterface $rpc): MetricsInterface => new Metrics($rpc),
+        ];
     }
 }

--- a/src/Bootloader/RoadRunnerBootloader.php
+++ b/src/Bootloader/RoadRunnerBootloader.php
@@ -22,7 +22,7 @@ final class RoadRunnerBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
-            EnvironmentInterface::class => static fn(
+            EnvironmentInterface::class => static fn (
                 GlobalEnvironmentInterface $env,
             ): EnvironmentInterface => new Environment($env->getAll()),
 
@@ -31,11 +31,11 @@ final class RoadRunnerBootloader extends Bootloader
             RPC::class => RPCInterface::class,
             RPCInterface::class =>
             /** @psalm-suppress ArgumentTypeCoercion */
-                static fn(
+                static fn (
                     EnvironmentInterface $env,
                 ): RPCInterface => new RPC(Relay::create($env->getRPCAddress())),
 
-            WorkerInterface::class => static fn(
+            WorkerInterface::class => static fn (
                 EnvironmentInterface $env,
             ): WorkerInterface => Worker::createFromEnvironment($env),
 

--- a/src/Bootloader/RoadRunnerBootloader.php
+++ b/src/Bootloader/RoadRunnerBootloader.php
@@ -19,16 +19,29 @@ use Spiral\RoadRunnerBridge\FallbackDispatcher;
 
 final class RoadRunnerBootloader extends Bootloader
 {
-    protected const SINGLETONS = [
-        EnvironmentInterface::class => [self::class, 'initEnvironment'],
-        Environment::class => EnvironmentInterface::class,
+    public function defineSingletons(): array
+    {
+        return [
+            EnvironmentInterface::class => static fn(
+                GlobalEnvironmentInterface $env,
+            ): EnvironmentInterface => new Environment($env->getAll()),
 
-        RPC::class => RPCInterface::class,
-        RPCInterface::class => [self::class, 'initRPC'],
+            Environment::class => EnvironmentInterface::class,
 
-        Worker::class => WorkerInterface::class,
-        WorkerInterface::class => [self::class, 'initWorker'],
-    ];
+            RPC::class => RPCInterface::class,
+            RPCInterface::class =>
+            /** @psalm-suppress ArgumentTypeCoercion */
+                static fn(
+                    EnvironmentInterface $env,
+                ): RPCInterface => new RPC(Relay::create($env->getRPCAddress())),
+
+            WorkerInterface::class => static fn(
+                EnvironmentInterface $env,
+            ): WorkerInterface => Worker::createFromEnvironment($env),
+
+            Worker::class => WorkerInterface::class,
+        ];
+    }
 
     public function init(AbstractKernel $kernel): void
     {
@@ -37,23 +50,5 @@ final class RoadRunnerBootloader extends Bootloader
         $kernel->bootstrapped(static function (FallbackDispatcher $dispatcher, KernelInterface $kernel): void {
             $kernel->addDispatcher($dispatcher);
         });
-    }
-
-    private function initEnvironment(GlobalEnvironmentInterface $env): EnvironmentInterface
-    {
-        return new Environment($env->getAll());
-    }
-
-    /**
-     * @psalm-suppress ArgumentTypeCoercion
-     */
-    private function initRPC(EnvironmentInterface $env): RPCInterface
-    {
-        return new RPC(Relay::create($env->getRPCAddress()));
-    }
-
-    private function initWorker(EnvironmentInterface $env): WorkerInterface
-    {
-        return Worker::createFromEnvironment($env);
     }
 }

--- a/src/Bootloader/ScaffolderBootloader.php
+++ b/src/Bootloader/ScaffolderBootloader.php
@@ -17,14 +17,17 @@ use Spiral\Scaffolder\Bootloader\ScaffolderBootloader as BaseScaffolderBootloade
 
 final class ScaffolderBootloader extends Bootloader
 {
-    public const DEPENDENCIES = [
-        ConsoleBootloader::class,
-        BaseScaffolderBootloader::class,
-    ];
-
     public function __construct(
-        private readonly ContainerInterface $container
+        private readonly ContainerInterface $container,
     ) {
+    }
+
+    public function defineDependencies(): array
+    {
+        return [
+            ConsoleBootloader::class,
+            BaseScaffolderBootloader::class,
+        ];
     }
 
     public function init(BaseScaffolderBootloader $scaffolder, ConsoleBootloader $console): void

--- a/src/Bootloader/TcpBootloader.php
+++ b/src/Bootloader/TcpBootloader.php
@@ -18,19 +18,25 @@ use Spiral\RoadRunnerBridge\Tcp\Service;
 
 final class TcpBootloader extends Bootloader
 {
-    protected const DEPENDENCIES = [
-        RoadRunnerBootloader::class,
-    ];
-
-    protected const SINGLETONS = [
-        Service\RegistryInterface::class => [self::class, 'initServiceRegistry'],
-        Interceptor\RegistryInterface::class => [self::class, 'initInterceptorRegistry'],
-        Server::class => Server::class,
-    ];
-
     public function __construct(
-        private readonly ConfiguratorInterface $config
+        private readonly ConfiguratorInterface $config,
     ) {
+    }
+
+    public function defineDependencies(): array
+    {
+        return [
+            RoadRunnerBootloader::class,
+        ];
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            Service\RegistryInterface::class => [self::class, 'initServiceRegistry'],
+            Interceptor\RegistryInterface::class => [self::class, 'initInterceptorRegistry'],
+            Server::class => Server::class,
+        ];
     }
 
     public function init(EnvironmentInterface $environment): void
@@ -51,20 +57,20 @@ final class TcpBootloader extends Bootloader
                 'services' => [],
                 'interceptors' => [],
                 'debug' => $environment->get('TCP_DEBUG', false),
-            ]
+            ],
         );
     }
 
     private function initInterceptorRegistry(
         TcpConfig $config,
-        ContainerInterface $container
+        ContainerInterface $container,
     ): Interceptor\RegistryInterface {
         return new Interceptor\InterceptorRegistry($config->getInterceptors(), $container);
     }
 
     private function initServiceRegistry(
         TcpConfig $config,
-        ContainerInterface $container
+        ContainerInterface $container,
     ): Service\RegistryInterface {
         return new Service\ServiceRegistry($config->getServices(), $container);
     }

--- a/src/Centrifugo/Broadcast.php
+++ b/src/Centrifugo/Broadcast.php
@@ -10,11 +10,11 @@ use Spiral\Broadcasting\Driver\AbstractBroadcast;
 final class Broadcast extends AbstractBroadcast
 {
     public function __construct(
-        private readonly CentrifugoApiInterface $api
+        private readonly CentrifugoApiInterface $api,
     ) {
     }
 
-    public function publish(iterable|\Stringable|string $topics, iterable|string $messages): void
+    public function publish(iterable|\Stringable|string $topics, iterable|\Stringable|string $messages): void
     {
         /** @var non-empty-string[] $topics */
         $topics = $this->formatTopics($this->toArray($topics));


### PR DESCRIPTION
This integration marks a significant enhancement in our capability to handle resource locks efficiently in PHP applications, leveraging the power and speed of GO.

### What is the RoadRunner Lock Plugin?

The RoadRunner lock plugin is a sophisticated tool designed for managing resource locks in applications through the RPC protocol. By combining the robustness of GO with the flexibility of PHP, it offers a solution that is both lightweight and speedy, ensuring reliable lock acquisition, release, and management.

Read more: https://roadrunner.dev/docs/plugins-locks

### Getting Started

To utilize this feature, simply register the `Spiral\RoadRunnerBridge\Bootloader\LockBootloader` in your application. 

Here's a quick snippet to get you started:

```php
use Spiral\RoadRunnerBridge\Bootloader as RoadRunnerBridge;

protected const LOAD = [
    // ...
    RoadRunnerBridge\LockBootloader::class,
    // ...
];
```

That's all it takes! No additional configuration is required on the RoadRunner side.

### Usage Example

Here's a brief example of how you can use locks in your application:

```php
$locks = $container->get(\RoadRunner\Lock\LockInterface::class);
$id = $lock->lock('pdf:create');

// Your logic for creating a PDF file

$lock->release('pdf:create', $id);
```


| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #93