### PR TITLE
Enhancements to Centrifugo Handler Class Generator

### DIFF
--- a/src/Console/Command/Scaffolder/CentrifugoHandlerCommand.php
+++ b/src/Console/Command/Scaffolder/CentrifugoHandlerCommand.php
@@ -24,12 +24,145 @@ final class CentrifugoHandlerCommand extends AbstractCommand
     #[Option(description: 'Optional, specify a custom namespace')]
     private ?string $namespace = null;
 
+    #[Option(shortcut: 't', description: 'Service type [connect, subscribe, rpc, refresh, publish]')]
+    private string $type = 'connect';
+
+    #[Option(name: 'with-api', shortcut: 'a', description: 'With API dependency')]
+    private bool $withApi = false;
+
     public function perform(): int
     {
-        $declaration = $this->createDeclaration(CentrifugoHandlerDeclaration::class);
+        $declaration = $this->createDeclaration(CentrifugoHandlerDeclaration::class, [
+            'withApi' => $this->withApi,
+        ]);
+
+        $type = match ($this->type) {
+            'connect' => [
+                'request' => \RoadRunner\Centrifugo\Request\Connect::class,
+                'use' => [
+                    \RoadRunner\Centrifugo\Payload\ConnectResponse::class,
+                ],
+                'body' => $this->createConnectHandlerBody(),
+            ],
+            'subscribe' => [
+                'request' => \RoadRunner\Centrifugo\Request\Subscribe::class,
+                'use' => [
+                    \RoadRunner\Centrifugo\Payload\SubscribeResponse::class,
+                ],
+                'body' => $this->createSubscribeHandlerBody(),
+            ],
+            'rpc' => [
+                'request' => \RoadRunner\Centrifugo\Request\RPC::class,
+                'use' => [
+                    \RoadRunner\Centrifugo\Payload\RPCResponse::class,
+                ],
+                'body' => $this->createRpcHandlerBody(),
+            ],
+            'refresh' => [
+                'request' => \RoadRunner\Centrifugo\Request\Refresh::class,
+                'use' => [
+                    \RoadRunner\Centrifugo\Payload\RefreshResponse::class,
+                ],
+                'body' => $this->createRefreshHandlerBody(),
+            ],
+            'publish' => [
+                'request' => \RoadRunner\Centrifugo\Request\Publish::class,
+                'use' => [
+                    \RoadRunner\Centrifugo\Payload\PublishResponse::class,
+                ],
+                'body' => $this->createPublishHandlerBody(),
+            ],
+            default => throw new \InvalidArgumentException('Invalid service type'),
+        };
+
+        $declaration->setType($type);
 
         $this->writeDeclaration($declaration);
 
         return self::SUCCESS;
+    }
+
+    private function createConnectHandlerBody(): string
+    {
+        return <<<'PHP'
+try {
+    $request->respond(
+        new ConnectResponse(
+            user: '', // User ID
+            channels: [
+                // List of channels to subscribe to on connect to Centrifugo
+                // 'public',
+            ],
+        )
+    );
+} catch (\Throwable $e) {
+    $request->error($e->getCode(), $e->getMessage());
+}
+PHP;
+    }
+
+    private function createSubscribeHandlerBody(): string
+    {
+        return <<<'PHP'
+try {
+    // Here you can check if user is allowed to subscribe to requested channel
+    if ($request->channel !== 'public') {
+        $request->disconnect('403', 'Channel is not allowed.');
+        return;
+    }
+
+    $request->respond(
+        new SubscribeResponse()
+    );
+} catch (\Throwable $e) {
+    $request->error($e->getCode(), $e->getMessage());
+}
+PHP;
+    }
+
+    private function createRpcHandlerBody(): string
+    {
+        return <<<'PHP'
+$result = match ($request->method) {
+    'ping' => ['pong' => 'pong', 'code' => 200],
+    default => ['error' => 'Not found', 'code' => 404]
+};
+
+try {
+    $request->respond(
+        new RPCResponse(
+            data: $result
+        )
+    );
+} catch (\Throwable $e) {
+    $request->error($e->getCode(), $e->getMessage());
+}
+PHP;
+    }
+
+    private function createRefreshHandlerBody(): string
+    {
+        return <<<'PHP'
+try {
+    $request->respond(
+        new RefreshResponse(...)
+    );
+} catch (\Throwable $e) {
+    $request->error($e->getCode(), $e->getMessage());
+}
+PHP;
+    }
+
+    private function createPublishHandlerBody(): string
+    {
+        return <<<'PHP'
+try {
+    $request->respond(
+        new PublishResponse(...)
+    );
+} catch (\Throwable $e) {
+    $request->error($e->getCode(), $e->getMessage());
+}
+PHP;
     }
 }

--- a/src/Scaffolder/Declaration/CentrifugoHandlerDeclaration.php
+++ b/src/Scaffolder/Declaration/CentrifugoHandlerDeclaration.php
@@ -5,26 +5,70 @@ declare(strict_types=1);
 namespace Spiral\RoadRunnerBridge\Scaffolder\Declaration;
 
 use RoadRunner\Centrifugo\CentrifugoApiInterface;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
+use Spiral\Scaffolder\Config\ScaffolderConfig;
 use Spiral\Scaffolder\Declaration\AbstractDeclaration;
+use Spiral\Scaffolder\Declaration\HasInstructions;
 
-class CentrifugoHandlerDeclaration extends AbstractDeclaration
+class CentrifugoHandlerDeclaration extends AbstractDeclaration implements HasInstructions
 {
     public const TYPE = 'centrifugo-handler';
 
+    public function __construct(
+        ScaffolderConfig $config,
+        string $name,
+        ?string $comment = null,
+        ?string $namespace = null,
+        private bool $withApi = false,
+    ) {
+        parent::__construct($config, $name, $comment, $namespace);
+    }
+
     public function declare(): void
     {
-        $this->namespace->addUse(CentrifugoApiInterface::class);
-
         $this->class->setFinal();
 
-        $this->class->addMethod('__construct')
-            ->setPublic()
-            ->addPromotedParameter('api')
-            ->setPrivate()
-            ->setReadOnly()
-            ->setType(CentrifugoApiInterface::class)
-        ;
+        if ($this->withApi) {
+            $this->namespace->addUse(CentrifugoApiInterface::class);
 
-        $this->class->addMethod('handle')->setPublic()->setReturnType('void');
+            $this->class->addMethod('__construct')
+                ->setPublic()
+                ->addPromotedParameter('api')
+                ->setPrivate()
+                ->setReadOnly()
+                ->setType(CentrifugoApiInterface::class);
+        }
+    }
+
+    public function setType(array $data): void
+    {
+        $this->namespace->addUse($data['request']);
+        $this->namespace->addUse(RequestInterface::class);
+        $this->namespace->addUse(ServiceInterface::class);
+
+        foreach ($data['use'] as $use) {
+            $this->namespace->addUse($use);
+        }
+
+        $className = (new \ReflectionClass($data['request']))->getShortName();
+
+        $this->class
+            ->addImplement(ServiceInterface::class)
+            ->addMethod('handle')
+            ->setPublic()
+            ->setBody($data['body'] ?? '// Put your code here')
+            ->setReturnType('void')
+            ->setComment("\n@param {$className} \$request")
+            ->addParameter('request')
+            ->setType(RequestInterface::class);
+    }
+
+    public function getInstructions(): array
+    {
+        return [
+            'Register your handler in `app/config/centrifugo.php` file. Read more in the documentation: https://spiral.dev/docs/websockets-services#service-registration',
+            'Read more about Centrifugo handlers: https://spiral.dev/docs/websockets-services',
+        ];
     }
 }

--- a/tests/src/Console/Command/Scaffolder/CentrifugoHandlerCommandTest.php
+++ b/tests/src/Console/Command/Scaffolder/CentrifugoHandlerCommandTest.php
@@ -23,20 +23,243 @@ declare(strict_types=1);
 
 namespace Spiral\Testing\Endpoint\Centrifugo\Handler;
 
-use RoadRunner\Centrifugo\CentrifugoApiInterface;
+use RoadRunner\Centrifugo\Payload\ConnectResponse;
+use RoadRunner\Centrifugo\Request\Connect;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
 
 /**
  * Sample Handler
  */
-final class SampleHandler
+final class SampleHandler implements ServiceInterface
 {
-    public function __construct(
-        private readonly CentrifugoApiInterface $api,
-    ) {
+    /**
+     * @param Connect $request
+     */
+    public function handle(RequestInterface $request): void
+    {
+        try {
+            $request->respond(
+                new ConnectResponse(
+                    user: '', // User ID
+                    channels: [
+                        // List of channels to subscribe to on connect to Centrifugo
+                        // 'public',
+                    ],
+                )
+            );
+        } catch (\Throwable $e) {
+            $request->error($e->getCode(), $e->getMessage());
+        }
+    }
+}
+
+PHP,
+            expectedFilename: 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php',
+            expectedOutputStrings: [
+                "SampleHandler' has been successfully written into 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php",
+            ],
+        );
     }
 
-    public function handle(): void
+    public function testScaffoldSubscribe(): void
     {
+        $this->assertScaffolderCommandSame(
+            command: 'create:centrifugo-handler',
+            args: [
+                'name' => 'sample',
+                '--type' => 'subscribe',
+                '--comment' => 'Sample Handler',
+            ],
+            expected: <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Endpoint\Centrifugo\Handler;
+
+use RoadRunner\Centrifugo\Payload\SubscribeResponse;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use RoadRunner\Centrifugo\Request\Subscribe;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
+
+/**
+ * Sample Handler
+ */
+final class SampleHandler implements ServiceInterface
+{
+    /**
+     * @param Subscribe $request
+     */
+    public function handle(RequestInterface $request): void
+    {
+        try {
+            // Here you can check if user is allowed to subscribe to requested channel
+            if ($request->channel !== 'public') {
+                $request->disconnect('403', 'Channel is not allowed.');
+                return;
+            }
+
+            $request->respond(
+                new SubscribeResponse()
+            );
+        } catch (\Throwable $e) {
+            $request->error($e->getCode(), $e->getMessage());
+        }
+    }
+}
+
+PHP,
+            expectedFilename: 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php',
+            expectedOutputStrings: [
+                "SampleHandler' has been successfully written into 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php",
+            ],
+        );
+    }
+
+    public function testScaffoldRpc(): void
+    {
+        $this->assertScaffolderCommandSame(
+            command: 'create:centrifugo-handler',
+            args: [
+                'name' => 'sample',
+                '--type' => 'rpc',
+                '--comment' => 'Sample Handler',
+            ],
+            expected: <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Endpoint\Centrifugo\Handler;
+
+use RoadRunner\Centrifugo\Payload\RPCResponse;
+use RoadRunner\Centrifugo\Request\RPC;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
+
+/**
+ * Sample Handler
+ */
+final class SampleHandler implements ServiceInterface
+{
+    /**
+     * @param RPC $request
+     */
+    public function handle(RequestInterface $request): void
+    {
+        $result = match ($request->method) {
+            'ping' => ['pong' => 'pong', 'code' => 200],
+            default => ['error' => 'Not found', 'code' => 404]
+        };
+
+        try {
+            $request->respond(
+                new RPCResponse(
+                    data: $result
+                )
+            );
+        } catch (\Throwable $e) {
+            $request->error($e->getCode(), $e->getMessage());
+        }
+    }
+}
+
+PHP,
+            expectedFilename: 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php',
+            expectedOutputStrings: [
+                "SampleHandler' has been successfully written into 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php",
+            ],
+        );
+    }
+
+    public function testScaffoldRefresh(): void
+    {
+        $this->assertScaffolderCommandSame(
+            command: 'create:centrifugo-handler',
+            args: [
+                'name' => 'sample',
+                '--type' => 'refresh',
+                '--comment' => 'Sample Handler',
+            ],
+            expected: <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Endpoint\Centrifugo\Handler;
+
+use RoadRunner\Centrifugo\Payload\RefreshResponse;
+use RoadRunner\Centrifugo\Request\Refresh;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
+
+/**
+ * Sample Handler
+ */
+final class SampleHandler implements ServiceInterface
+{
+    /**
+     * @param Refresh $request
+     */
+    public function handle(RequestInterface $request): void
+    {
+        try {
+            $request->respond(
+                new RefreshResponse(...)
+            );
+        } catch (\Throwable $e) {
+            $request->error($e->getCode(), $e->getMessage());
+        }
+    }
+}
+
+PHP,
+            expectedFilename: 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php',
+            expectedOutputStrings: [
+                "SampleHandler' has been successfully written into 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php",
+            ],
+        );
+    }
+
+    public function testScaffoldPublish(): void
+    {
+        $this->assertScaffolderCommandSame(
+            command: 'create:centrifugo-handler',
+            args: [
+                'name' => 'sample',
+                '--type' => 'publish',
+                '--comment' => 'Sample Handler',
+            ],
+            expected: <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Endpoint\Centrifugo\Handler;
+
+use RoadRunner\Centrifugo\Payload\PublishResponse;
+use RoadRunner\Centrifugo\Request\Publish;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
+
+/**
+ * Sample Handler
+ */
+final class SampleHandler implements ServiceInterface
+{
+    /**
+     * @param Publish $request
+     */
+    public function handle(RequestInterface $request): void
+    {
+        try {
+            $request->respond(
+                new PublishResponse(...)
+            );
+        } catch (\Throwable $e) {
+            $request->error($e->getCode(), $e->getMessage());
+        }
     }
 }
 
@@ -63,17 +286,89 @@ declare(strict_types=1);
 
 namespace Spiral\Testing\Endpoint\Centrifugo\Other;
 
-use RoadRunner\Centrifugo\CentrifugoApiInterface;
+use RoadRunner\Centrifugo\Payload\ConnectResponse;
+use RoadRunner\Centrifugo\Request\Connect;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
 
-final class SampleHandler
+final class SampleHandler implements ServiceInterface
+{
+    /**
+     * @param Connect $request
+     */
+    public function handle(RequestInterface $request): void
+    {
+        try {
+            $request->respond(
+                new ConnectResponse(
+                    user: '', // User ID
+                    channels: [
+                        // List of channels to subscribe to on connect to Centrifugo
+                        // 'public',
+                    ],
+                )
+            );
+        } catch (\Throwable $e) {
+            $request->error($e->getCode(), $e->getMessage());
+        }
+    }
+}
+
+PHP,
+            expectedFilename: 'app/src/Endpoint/Centrifugo/Other/SampleHandler.php',
+            expectedOutputStrings: [
+                "SampleHandler' has been successfully written into 'app/src/Endpoint/Centrifugo/Other/SampleHandler.php",
+            ],
+        );
+    }
+
+    public function testScaffoldWithApi(): void
+    {
+        $this->assertScaffolderCommandSame(
+            command: 'create:centrifugo-handler',
+            args: [
+                'name' => 'sample',
+                '--with-api' => true,
+                '--namespace' => 'Spiral\\Testing\\Endpoint\\Centrifugo\\Other',
+            ],
+            expected: <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Endpoint\Centrifugo\Other;
+
+use RoadRunner\Centrifugo\CentrifugoApiInterface;
+use RoadRunner\Centrifugo\Payload\ConnectResponse;
+use RoadRunner\Centrifugo\Request\Connect;
+use RoadRunner\Centrifugo\Request\RequestInterface;
+use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;
+
+final class SampleHandler implements ServiceInterface
 {
     public function __construct(
         private readonly CentrifugoApiInterface $api,
     ) {
     }
 
-    public function handle(): void
+    /**
+     * @param Connect $request
+     */
+    public function handle(RequestInterface $request): void
     {
+        try {
+            $request->respond(
+                new ConnectResponse(
+                    user: '', // User ID
+                    channels: [
+                        // List of channels to subscribe to on connect to Centrifugo
+                        // 'public',
+                    ],
+                )
+            );
+        } catch (\Throwable $e) {
+            $request->error($e->getCode(), $e->getMessage());
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the class generator for Centrifugo handlers. The refactor enhances the functionality of the generator, enabling it to create diverse handler types catering to various aspects of Centrifugo server interaction.

### Changes

1. **Expanded Handler Types**: The generator now supports multiple handler types: `connect`, `subscribe`, `rpc`, `refresh`, and `publish`. Each type corresponds to different interactions with the Centrifugo server, providing tailored functionality for specific use cases.
    
2. **Default Handler Type**: The default command (`php app.php create:centrifugo-handler Simple`) now generates a `connect` type handler, aligning with the most common use case.
    
3. **Enhanced Code Templates**: Each handler type comes with its specific code template, ensuring that generated classes are immediately relevant and useful. This update enhances developer experience and reduces the need for manual modifications post-generation.

#### Before

```php
<?php

declare(strict_types=1);

namespace Spiral\Testing\Endpoint\Centrifugo\Handler;

use RoadRunner\Centrifugo\CentrifugoApiInterface;

/**
 * Sample Handler
 */
final class SampleHandler
{
    public function __construct(
        private readonly CentrifugoApiInterface $api,
    ) {
    }

    public function handle(): void
    {
         // ...
    }
}
```

Here are example of handlers:

#### Connect

**Command:**

```bash
php app.php create:centrifugo-handler Connect
```

**Result:**

```php
<?php

declare(strict_types=1);

namespace Spiral\Testing\Endpoint\Centrifugo\Handler;

use RoadRunner\Centrifugo\Payload\ConnectResponse;
use RoadRunner\Centrifugo\Request\Connect;
use RoadRunner\Centrifugo\Request\RequestInterface;
use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;

final class ConnectHandler implements ServiceInterface
{
    /**
     * @param Connect $request
     */
    public function handle(RequestInterface $request): void
    {
        try {
            $request->respond(
                new ConnectResponse(
                    user: '', // User ID
                    channels: [
                        // List of channels to subscribe to on connect to Centrifugo
                        // 'public',
                    ],
                )
            );
        } catch (\Throwable $e) {
            $request->error($e->getCode(), $e->getMessage());
        }
    }
}
```

#### Subscribe

**Command:**

```bash
php app.php create:centrifugo-handler Subscribe -t=subscribe
```

**Result:**

```php
<?php

declare(strict_types=1);

namespace Spiral\Testing\Endpoint\Centrifugo\Handler;

use RoadRunner\Centrifugo\Payload\SubscribeResponse;
use RoadRunner\Centrifugo\Request\RequestInterface;
use RoadRunner\Centrifugo\Request\Subscribe;
use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;

final class SubscribeHandler implements ServiceInterface
{
    /**
     * @param Subscribe $request
     */
    public function handle(RequestInterface $request): void
    {
        try {
            // Here you can check if user is allowed to subscribe to requested channel
            if ($request->channel !== 'public') {
                $request->disconnect('403', 'Channel is not allowed.');
                return;
            }

            $request->respond(
                new SubscribeResponse()
            );
        } catch (\Throwable $e) {
            $request->error($e->getCode(), $e->getMessage());
        }
    }
}
```

#### RPC

**Command:**

```bash
php app.php create:centrifugo-handler Rpc -t=rpc
```

**Result:**

```php
<?php

declare(strict_types=1);

namespace Spiral\Testing\Endpoint\Centrifugo\Handler;

use RoadRunner\Centrifugo\Payload\RPCResponse;
use RoadRunner\Centrifugo\Request\RPC;
use RoadRunner\Centrifugo\Request\RequestInterface;
use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;

final class RpcHandler implements ServiceInterface
{
    /**
     * @param RPC $request
     */
    public function handle(RequestInterface $request): void
    {
        $result = match ($request->method) {
            'ping' => ['pong' => 'pong', 'code' => 200],
            default => ['error' => 'Not found', 'code' => 404]
        };

        try {
            $request->respond(
                new RPCResponse(
                    data: $result
                )
            );
        } catch (\Throwable $e) {
            $request->error($e->getCode(), $e->getMessage());
        }
    }
}
```

#### Refresh

**Command:**

```bash
php app.php create:centrifugo-handler Refresh -t=refresh
```

**Result:**

```php
<?php

declare(strict_types=1);

namespace Spiral\Testing\Endpoint\Centrifugo\Handler;

use RoadRunner\Centrifugo\Payload\RefreshResponse;
use RoadRunner\Centrifugo\Request\Refresh;
use RoadRunner\Centrifugo\Request\RequestInterface;
use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;

final class RefreshHandler implements ServiceInterface
{
    /**
     * @param Refresh $request
     */
    public function handle(RequestInterface $request): void
    {
        try {
            $request->respond(
                new RefreshResponse(...)
            );
        } catch (\Throwable $e) {
            $request->error($e->getCode(), $e->getMessage());
        }
    }
}
```


#### Publish

**Command:**

```bash
php app.php create:centrifugo-handler Publish -t=publish
```

**Result:**

```php
<?php

declare(strict_types=1);

namespace Spiral\Testing\Endpoint\Centrifugo\Handler;

use RoadRunner\Centrifugo\Payload\PublishResponse;
use RoadRunner\Centrifugo\Request\Publish;
use RoadRunner\Centrifugo\Request\RequestInterface;
use Spiral\RoadRunnerBridge\Centrifugo\ServiceInterface;

final class PublishHandler implements ServiceInterface
{
    /**
     * @param Publish $request
     */
    public function handle(RequestInterface $request): void
    {
        try {
            $request->respond(
                new PublishResponse(...)
            );
        } catch (\Throwable $e) {
            $request->error($e->getCode(), $e->getMessage());
        }
    }
}
```


5. **Improved Command Output**: The output of the generator command has been enriched with additional information. It now not only confirms the successful creation of the handler but also provides next steps and references to relevant documentation, improving guidance for further development.

**Before**

```bash
Declaration of 'SampleHandler' has been successfully written into 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php
```

**After**

```bash
Declaration of 'SampleHandler' has been successfully written into 'app/src/Endpoint/Centrifugo/Handler/SampleHandler.php'.

Next steps:
1. Register your handler in `app/config/centrifugo.php` file. Read more in the documentation: https://spiral.dev/docs/websockets-services#service-registration
2. Read more about Centrifugo handlers: https://spiral.dev/docs/websockets-services
```

---

This enhancement fosters a more efficient and streamlined workflow for developers working with Centrifugo in our PHP environment. It not only saves time but also ensures consistency and adherence to best practices across different types of handlers.