### PR TITLE
Adding Exception handling when searching for a handler

### DIFF
--- a/src/GRPC/ServiceLocator.php
+++ b/src/GRPC/ServiceLocator.php
@@ -22,7 +22,7 @@ final class ServiceLocator implements LocatorInterface
         $result = [];
 
         foreach ($this->classes->getClasses(ServiceInterface::class) as $service) {
-            if (! $service->isInstantiable()) {
+            if (!$service->isInstantiable()) {
                 continue;
             }
 

--- a/src/Queue/PayloadDeserializer.php
+++ b/src/Queue/PayloadDeserializer.php
@@ -35,9 +35,10 @@ final class PayloadDeserializer implements PayloadDeserializerInterface
             return $serializer->unserialize($payload, $class);
         }
 
-        $class = $this->detectTypeFromJobHandler(
-            $this->registry->getHandler($name),
-        );
+        try {
+            $class = $this->detectTypeFromJobHandler($this->registry->getHandler($name));
+        } catch (\Throwable) {
+        }
 
         if ($class === 'string') {
             return $payload;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

If a job is pushed by some script (not using our packages), it will have a default name set to **deduced_by_rr**. A handler for this name may not be configured. For example, it could be selected based on a Kafka topic in an interceptor. In such a case, the application should not throw an exception during the payload deserialization stage.

Related to: https://github.com/orgs/roadrunner-server/discussions/1802