### PR TITLE
Add support for monolog/monolog 3.x

### DIFF
--- a/src/Logger/Handler.php
+++ b/src/Logger/Handler.php
@@ -8,7 +8,9 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Handler\HandlerInterface;
+use Monolog\Level;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use RoadRunner\Logger\Logger as RoadRunnerLogger;
 
 final class Handler extends AbstractProcessingHandler
@@ -29,7 +31,7 @@ final class Handler extends AbstractProcessingHandler
         $this->setFormatter($formatter);
     }
 
-    public function handle(array $record): bool
+    public function handle(array|LogRecord $record): bool
     {
         if ($this->fallbackHandler !== null) {
             return $this->fallbackHandler->handle($record);
@@ -38,11 +40,12 @@ final class Handler extends AbstractProcessingHandler
         return parent::handle($record);
     }
 
-    protected function write(array $record): void
+    protected function write(array|LogRecord $record): void
     {
         $message = $record['formatted'];
 
-        match ($record['level']) {
+        $level = $record['level'] instanceof Level ? $record['level']->value : $record['level'];
+        match ($level) {
             Logger::ERROR, Logger::CRITICAL => $this->logger->error($message),
             Logger::WARNING, Logger::ALERT, Logger::EMERGENCY => $this->logger->warning($message),
             Logger::INFO, Logger::NOTICE => $this->logger->info($message),

--- a/src/Logger/Handler.php
+++ b/src/Logger/Handler.php
@@ -42,9 +42,13 @@ final class Handler extends AbstractProcessingHandler
 
     protected function write(array|LogRecord $record): void
     {
+        /** @psalm-suppress InvalidArgument */
         $message = $record['formatted'];
+        \assert(\is_string($message) || $message instanceof \Stringable);
 
         $level = $record['level'] instanceof Level ? $record['level']->value : $record['level'];
+
+        /** @psalm-suppress DeprecatedConstant */
         match ($level) {
             Logger::ERROR, Logger::CRITICAL => $this->logger->error($message),
             Logger::WARNING, Logger::ALERT, Logger::EMERGENCY => $this->logger->warning($message),

--- a/tests/src/Logger/HandlerTest.php
+++ b/tests/src/Logger/HandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Logger;
 
+use Monolog\LogRecord;
 use RoadRunner\Logger\Logger;
 use Spiral\Goridge\RPC\RPCInterface;
 use Monolog\Handler\HandlerInterface;
@@ -54,7 +55,7 @@ final class HandlerTest extends TestCase
             ),
         ]);
 
-        $fallback->shouldReceive('handle')->withArgs(function (array $record) {
+        $fallback->shouldReceive('handle')->withArgs(function (array|LogRecord $record) {
             return $record['message'] === 'Error message';
         })->andReturn(true);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ❌ 

The implementation of [Handler](https://github.com/spiral/roadrunner-bridge/blob/3.x/src/Logger/Handler.php#L32) should be compatible with [HandlerInterface](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/HandlerInterface.php#L50) and be able to accept a **[LogRecord](https://github.com/Seldaek/monolog/blob/main/src/Monolog/LogRecord.php#L22)** object. The object implements the **ArrayAccess** interface and can be used as an array.

The Psalm error will be fixed after the pull request is merged here: https://github.com/spiral/framework/pull/1049