### PR TITLE
Fix `proto_path` params order

### DIFF
--- a/src/GRPC/ProtocCommandBuilder.php
+++ b/src/GRPC/ProtocCommandBuilder.php
@@ -45,8 +45,9 @@ final class ProtocCommandBuilder
     private function buildDirs(string $protoDir): string
     {
         $dirs = \array_filter([
-            $this->config->getServicesBasePath(),
+            // The current directory must be first in the import path list to avoid proto-file name conflicts.
             $protoDir,
+            $this->config->getServicesBasePath(),
         ]);
 
         if ($dirs === []) {

--- a/tests/src/GRPC/ProtocCommandBuilderTest.php
+++ b/tests/src/GRPC/ProtocCommandBuilderTest.php
@@ -39,7 +39,7 @@ final class ProtocCommandBuilderTest extends TestCase
             ]);
 
         $this->assertSame(
-            "protoc --plugin=path3 --php_out='path2' --php-grpc_out='path2' -I='path4' -I='path1' 'message.proto' 'service.proto' 2>&1",
+            "protoc --plugin=path3 --php_out='path2' --php-grpc_out='path2' -I='path1' -I='path4' 'message.proto' 'service.proto' 2>&1",
             $builder->build('path1', 'path2')
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

Fixed an issue related with wrong import proto path parameters order.
If a few services in different import directories have the same name, an exception might be thrown:
_Input is shadowed in the --proto_path by "....proto". Either use the latter file as your input or reorder the --proto_path so that the former file's location comes first._

See https://stackoverflow.com/questions/69075367/assemble-error-while-using-latest-grpc-plugin-on-android-input-is-shadowed-in/78821330#78821330