### PR TITLE
Change log level from `error` to `warning` for pipeline declarations when a pipeline with the same name already exists

### DIFF
--- a/src/Queue/RPCPipelineRegistry.php
+++ b/src/Queue/RPCPipelineRegistry.php
@@ -65,7 +65,7 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
                 try {
                     $this->jobs->create($connector)->resume();
                 } catch (JobsException $e) {
-                    $this->logger->error(
+                    $this->logger->warning(
                         \sprintf(
                             'Unable to declare consumer pipeline "%s". Reason: %s',
                             $name,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
