### PR TITLE
Add Distributed Locking to Prevent Race Conditions in Pipeline Declaration

### DIFF
--- a/src/Bootloader/QueueBootloader.php
+++ b/src/Bootloader/QueueBootloader.php
@@ -28,6 +28,7 @@ final class QueueBootloader extends Bootloader
         return [
             RoadRunnerBootloader::class,
             SerializerBootloader::class,
+            LockBootloader::class,
         ];
     }
 

--- a/src/Queue/RPCPipelineRegistry.php
+++ b/src/Queue/RPCPipelineRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\RoadRunnerBridge\Queue;
 
 use Psr\Log\LoggerInterface;
+use RoadRunner\Lock\LockInterface;
 use Spiral\Queue\Exception\InvalidArgumentException;
 use Spiral\RoadRunner\Jobs\Exception\JobsException;
 use Spiral\RoadRunner\Jobs\Jobs;
@@ -35,6 +36,7 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
         private readonly LoggerInterface $logger,
         private readonly JobsInterface $jobs,
         private readonly RoadRunnerMode $mode,
+        private readonly LockInterface $lock,
         QueueConfig $config,
         private readonly int $ttl = 60,
     ) {
@@ -61,6 +63,15 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
 
             $connector = $this->getConnector($name);
 
+            if ($this->lock->exists($lock = 'rr-jobs-declare-' . $connector->getName())) {
+                continue;
+            }
+
+            $id = $this->lock->lock($lock);
+            if ($id === false) {
+                continue;
+            }
+
             if (!$this->isExists($connector)) {
                 try {
                     $this->jobs->create($connector)->resume();
@@ -74,6 +85,8 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
                     );
                 }
             }
+
+            $this->lock->release($lock, $id);
         }
     }
 
@@ -151,13 +164,13 @@ final class RPCPipelineRegistry implements PipelineRegistryInterface
         // Connector is required for pipeline declaration
         if (!isset($this->pipelines[$name]['connector'])) {
             throw new InvalidArgumentException(
-                \sprintf('You must specify connector for given pipeline `%s`.', $name)
+                \sprintf('You must specify connector for given pipeline `%s`.', $name),
             );
         }
 
         if (!$this->pipelines[$name]['connector'] instanceof CreateInfoInterface) {
             throw new InvalidArgumentException(
-                \sprintf('Connector should implement %s interface.', CreateInfoInterface::class)
+                \sprintf('Connector should implement %s interface.', CreateInfoInterface::class),
             );
         }
 

--- a/tests/src/Queue/RPCPipelineRegistryTest.php
+++ b/tests/src/Queue/RPCPipelineRegistryTest.php
@@ -7,6 +7,7 @@ namespace Spiral\Tests\Queue;
 use Hamcrest\Matchers;
 use Mockery as m;
 use Psr\Log\LoggerInterface;
+use RoadRunner\Lock\LockInterface;
 use Spiral\Queue\Exception\InvalidArgumentException;
 use Spiral\Queue\Options;
 use Spiral\RoadRunner\Jobs\JobsInterface;
@@ -28,6 +29,7 @@ final class RPCPipelineRegistryTest extends TestCase
     private m\LegacyMockInterface|m\MockInterface|CreateInfoInterface $amqpConnector;
     private JobsInterface|m\MockInterface|m\LegacyMockInterface $jobs;
     private LoggerInterface|m\LegacyMockInterface|m\MockInterface $logger;
+    private LockInterface|m\MockInterface|m\LegacyMockInterface $lock;
 
     public function makeJob(RoadRunnerMode $mode = RoadRunnerMode::Jobs): void
     {
@@ -47,6 +49,7 @@ final class RPCPipelineRegistryTest extends TestCase
             $this->logger = m::mock(LoggerInterface::class),
             $this->jobs = m::mock(JobsInterface::class),
             $mode,
+            $this->lock = m::mock(LockInterface::class),
             new QueueConfig([
                 'memory' => [
                     'connector' => $this->memoryConnector,
@@ -78,8 +81,41 @@ final class RPCPipelineRegistryTest extends TestCase
                     'options' => new KafkaOptions('foo', 100, 14),
                 ],
             ]),
-            60
+            60,
         );
+    }
+
+    private function assertLock(string $pipeline, bool $exists = false): void
+    {
+        $resource = 'rr-jobs-declare-' . $pipeline;
+        $id = 'some-lock-id-' . $pipeline;
+
+        $this->lock
+            ->shouldReceive('exists')
+            ->once()
+            ->with($resource)
+            ->andReturn($exists);
+
+        if (!$exists) {
+            $this->lock
+                ->shouldReceive('lock')
+                ->once()
+                ->with($resource)
+                ->andReturn($id);
+
+            $this->lock
+                ->shouldReceive('release')
+                ->once()
+                ->with($resource, $id);
+        } else {
+            $this->lock
+                ->shouldNotReceive('lock')
+                ->with($resource);
+
+            $this->lock
+                ->shouldNotReceive('release')
+                ->with($resource, $id);
+        }
     }
 
     public function testDeclareConsumersPipeline(): void
@@ -95,21 +131,45 @@ final class RPCPipelineRegistryTest extends TestCase
             ]),
         );
 
-        $this->jobs->shouldReceive('create')
+        $this->assertLock('amqp');
+        $this->assertLock('memory');
+        $this->assertLock('sqs');
+
+        $this->jobs
+            ->shouldReceive('create')
             ->once()
             ->with($this->localConnector)
             ->andReturn($queue = m::mock(QueueInterface::class));
+
         $queue->shouldReceive('resume')->once();
 
-        $this->jobs->shouldReceive('create')
+        $this->jobs
+            ->shouldReceive('create')
             ->once()
             ->with($this->memoryConnector)
             ->andReturn($queue = m::mock(QueueInterface::class));
 
-        $this->jobs->shouldNotReceive('create')
+        $this->jobs
+            ->shouldNotReceive('create')
             ->with($this->amqpConnector);
 
         $queue->shouldReceive('resume')->once();
+
+        $this->registry->declareConsumerPipelines();
+    }
+
+    public function testDeclarationShouldBeSkippedIfLocked(): void
+    {
+        $this->makeJob();
+        $this->amqpConnector->shouldReceive('getName')->andReturn('amqp');
+        $this->memoryConnector->shouldReceive('getName')->andReturn('memory');
+        $this->localConnector->shouldReceive('getName')->andReturn('sqs');
+
+        $this->assertLock('amqp', true);
+        $this->assertLock('memory', true);
+        $this->assertLock('sqs', true);
+
+        $this->jobs->shouldNotReceive('create');
 
         $this->registry->declareConsumerPipelines();
     }
@@ -127,7 +187,8 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->memoryConnector->shouldReceive('getName')->andReturn('local');
 
         $this->jobs->shouldReceive('getIterator')->once()->andReturn(new \ArrayIterator(['local' => '']));
-        $this->jobs->shouldReceive('connect')
+        $this->jobs
+            ->shouldReceive('connect')
             ->once()
             ->with('local', null)
             ->andReturn($queue = m::mock(QueueInterface::class));
@@ -144,7 +205,8 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->localConnector->shouldReceive('getName')->andReturn('with-queue-options');
 
         $this->jobs->shouldReceive('getIterator')->once()->andReturn(new \ArrayIterator(['with-queue-options' => '']));
-        $this->jobs->shouldReceive('connect')
+        $this->jobs
+            ->shouldReceive('connect')
             ->once()
             ->with('with-queue-options', Matchers::equalTo(new JobsOptions(5)))
             ->andReturn(m::mock(QueueInterface::class));
@@ -161,7 +223,8 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->localConnector->shouldReceive('getName')->andReturn('with-jobs-options');
 
         $this->jobs->shouldReceive('getIterator')->once()->andReturn(new \ArrayIterator(['with-jobs-options' => '']));
-        $this->jobs->shouldReceive('connect')
+        $this->jobs
+            ->shouldReceive('connect')
             ->once()
             ->with('with-jobs-options', Matchers::equalTo(new KafkaOptions('foo', 100, 14)))
             ->andReturn(m::mock(QueueInterface::class));
@@ -178,7 +241,8 @@ final class RPCPipelineRegistryTest extends TestCase
         $this->localConnector->shouldReceive('getName')->once()->andReturn('local');
 
         $this->jobs->shouldReceive('getIterator')->once()->andReturn(new \ArrayIterator(['memory']));
-        $this->jobs->shouldReceive('create')
+        $this->jobs
+            ->shouldReceive('create')
             ->once()
             ->with($this->localConnector, null)
             ->andReturn($queue = m::mock(QueueInterface::class));
@@ -192,7 +256,8 @@ final class RPCPipelineRegistryTest extends TestCase
     public function testGetsNonExistsPipelineShouldReturnQueue(): void
     {
         $this->makeJob();
-        $this->jobs->shouldReceive('connect')
+        $this->jobs
+            ->shouldReceive('connect')
             ->once()
             ->with('test')
             ->andReturn($queue = m::mock(QueueInterface::class));


### PR DESCRIPTION
When RoadRunner starts its worker pool for the `jobs` plugin, each worker process attempts to declare consumer pipelines during initialization. This creates a race condition where multiple workers try to create the same pipeline simultaneously, potentially leading to conflicts, duplicate creation attempts, and errors.

This PR introduces a distributed locking mechanism to the `RPCPipelineRegistry` class to ensure that only one worker process can declare a specific pipeline at a time during the worker pool initialization phase.

This issue is particularly problematic for the Kafka driver, where each pipeline declaration creates a Kafka consumer that joins the consumer group. When multiple workers declare the same pipeline simultaneously, phantom consumers are created in the Kafka consumer groups. These phantom consumers remain idle and don't consume messages from their assigned partitions, while only one consumer actually processes messages. This leads to:

- **Unprocessed messages** sitting in partitions assigned to phantom consumers
- **Reduced throughput** as available partitions are not being consumed
