### PR TITLE
Normalize TCP and Centrifugo interceptor arguments

### DIFF
--- a/src/Centrifugo/Internal/Server.php
+++ b/src/Centrifugo/Internal/Server.php
@@ -64,7 +64,7 @@ final class Server
                         new CallContext(
                             /** @see ServiceInterface::handle() */
                             Target::fromPair($services->getService($type), 'handle'),
-                            ['request' => $request],
+                            [$request],
                             [RequestType::class => $type],
                         ),
                     ),

--- a/src/Tcp/Internal/Server.php
+++ b/src/Tcp/Internal/Server.php
@@ -72,7 +72,7 @@ final class Server
                     static fn(): mixed => $pipeline->handle(new CallContext(
                         /** @see \Spiral\RoadRunnerBridge\Tcp\Service\ServiceInterface::handle() */
                         Target::fromPair($services->getService($server), 'handle'),
-                        ['request' => $request],
+                        [$request],
                         ['server' => $server],
                     )),
                 );

--- a/tests/app/Tcp/TestInterceptor.php
+++ b/tests/app/Tcp/TestInterceptor.php
@@ -15,17 +15,18 @@ class TestInterceptor implements CoreInterceptorInterface
 
     public function process(string $controller, string $action, array $parameters, CoreInterface $core): mixed
     {
+        $request = $parameters[0];
         if (\count($this->data) < 5) {
-            $this->data[] = $parameters['request']->getBody();
+            $this->data[] = $request->getBody();
         }
 
         if (\count($this->data) === 5) {
-            $parameters['request'] = new Request(
-                remoteAddr: $parameters['request']->getRemoteAddress(),
-                event: $parameters['request']->getEvent(),
+            $parameters[0] = new Request(
+                remoteAddr: $request->getRemoteAddress(),
+                event: $request->getEvent(),
                 body: \json_encode($this->data, JSON_THROW_ON_ERROR),
-                connectionUuid: $parameters['request']->getConnectionUuid(),
-                server: $parameters['request']->getServer(),
+                connectionUuid: $request->getConnectionUuid(),
+                server: $request->getServer(),
             );
 
             return $core->callAction($controller, $action, $parameters);


### PR DESCRIPTION
## What was changed

Declare arguments in TCP and Centrifugo interceptor Context as non-assoc array

## Why?

To be consistent

## Documentation <!--- Remove if not needed -->

https://github.com/spiral/docs/pull/717
